### PR TITLE
ci: add publish success comment to merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   ci:
@@ -42,5 +43,25 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
+        id: publish
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: npm publish --provenance
+
+      - name: Generate App token
+        id: app-token
+        if: steps.publish.outcome == 'success'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
+      - name: Post publish comment
+        if: steps.publish.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(git log -1 --format='%s' | grep -oP '\(#\K\d+(?=\))')
+          if [ -n "$PR_NUMBER" ]; then
+            VERSION=$(jq -r .version package.json)
+            gh pr comment "$PR_NUMBER" --body "**Merge bot:** Published [\`@auldrant/ui@$VERSION\`](https://www.npmjs.com/package/@auldrant/ui/v/$VERSION) to npm."
+          fi


### PR DESCRIPTION
## Summary
- Add publish success comment from merge bot on the merged PR when npm publish succeeds
- Comment includes a link to the published package version on npm

## Test Plan
- [x] Repo is now public (required for provenance)
- [ ] CI passes on this PR
- [ ] Merge bot merges the PR and publishes
- [ ] Verify comment appears on merged PR with correct version and link