### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] - 2026-02-26
+
+### Fixed
+
+- Add `repository` field to `package.json` with the GitHub repo URL ([#30](https://github.com/coloneljade/auldrant-ui/pull/30))
+- Required by Sigstore provenance verification during `npm publish --provenance` ([#30](https://github.com/coloneljade/auldrant-ui/pull/30))
+- Without it, publish fails with E422: `repository.url is "", expected to match` ([#30](https://github.com/coloneljade/auldrant-ui/pull/30))
+
 ## [0.5.0] - 2026-02-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auldrant/ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Accessible Preact component library with design tokens and CSS modules",
   "author": "Colonel Jade",


### PR DESCRIPTION
## Summary
- Add `repository` field to `package.json` with the GitHub repo URL
- Required by Sigstore provenance verification during `npm publish --provenance`
- Without it, publish fails with E422: `repository.url is "", expected to match`

## Test Plan
- [ ] CI passes
- [ ] Merge and verify npm publish succeeds
- [ ] Verify publish comment appears on this PR