### PR TITLE
fix: add homepage and bugs fields to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.2] - 2026-02-26
+
+### Fixed
+
+- Add `homepage` and `bugs` fields to `package.json` ([#31](https://github.com/coloneljade/auldrant-ui/pull/31))
+- npm renders these as links on the public package page ([#31](https://github.com/coloneljade/auldrant-ui/pull/31))
+
 ## [0.5.1] - 2026-02-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auldrant/ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "Accessible Preact component library with design tokens and CSS modules",
   "author": "Colonel Jade",


### PR DESCRIPTION
## Summary
- Add `homepage` and `bugs` fields to `package.json`
- npm renders these as links on the public package page

## Test Plan
- [ ] CI passes
- [ ] Verify npm publish succeeds (0.5.1 → 0.5.2)
- [ ] Verify publish comment appears