### PR TITLE
chore(vscode): add port forwarding and dev tasks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,17 @@
 			]
 		}
 	},
+	"forwardPorts": [5173, 6006],
+	"portsAttributes": {
+		"5173": {
+			"label": "Dev Test Page",
+			"onAutoForward": "openBrowser"
+		},
+		"6006": {
+			"label": "Storybook",
+			"onAutoForward": "openBrowser"
+		}
+	},
 	"postCreateCommand": "bun install",
 	"remoteUser": "bun"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -65,6 +65,31 @@
 			}
 		},
 		{
+			"label": "dev",
+			"type": "shell",
+			"command": "bun run dev",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared"
+			},
+			"problemMatcher": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "test:a11y",
+			"type": "shell",
+			"command": "bun run test:a11y",
+			"group": "test",
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared"
+			}
+		},
+		{
 			"label": "storybook",
 			"type": "shell",
 			"command": "bun run storybook",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:watch": "bun test --watch",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run build",
-    "dev": "vite",
+    "dev": "vite --host",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "test -n \"$CI\" || lefthook install"


### PR DESCRIPTION
## Summary
- chore(vscode): add port forwarding and dev tasks

## Details
- Adds devcontainer port forwarding for Vite (5173) and Storybook (6006) with auto-open browser
- Adds VS Code tasks for dev and test:a11y
- Sets build task as default group
- Enables --host flag on Vite dev server for container access

## Test Plan
- [ ] Verify devcontainer starts and port forwards work
- [ ] Verify VS Code tasks run (Ctrl+Shift+B for build, or run via task palette)
- [ ] Verify Vite dev server is accessible on port 5173