### PR TITLE
feat(Accordion): add collapsible disclosure component

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ function App() {
 
 ## Components
 
+### Disclosure
+
+| Component | Description | Key Props |
+|-----------|-------------|-----------|
+| `Accordion` | Collapsible disclosure sections with ARIA state and smooth animation | `items`, `exclusive?` |
+
 ### Feedback
 
 | Component | Description | Key Props |

--- a/dev/TestPage.tsx
+++ b/dev/TestPage.tsx
@@ -1,5 +1,6 @@
 import Theme from '@components/Theme';
 import type { FunctionComponent } from 'preact';
+import { AccordionSection } from './sections/AccordionSection';
 import { AlertSection } from './sections/AlertSection';
 import { BadgeSection } from './sections/BadgeSection';
 import { ButtonSection } from './sections/ButtonSection';
@@ -27,6 +28,7 @@ export const TestPage: FunctionComponent = () => (
 		<div class="dev-page" id="main">
 			<h1>Auldrant UI — Dev Test Page</h1>
 			<ThemeSwatches />
+			<AccordionSection />
 			<AlertSection />
 			<ButtonSection />
 			<SpinnerSection />

--- a/dev/sections/AccordionSection.tsx
+++ b/dev/sections/AccordionSection.tsx
@@ -1,0 +1,102 @@
+import type { IAccordionItem } from '@components/Accordion';
+import Accordion from '@components/Accordion';
+import type { FunctionComponent } from 'preact';
+
+const multiExpandItems: IAccordionItem[] = [
+	{
+		id: 'getting-started',
+		trigger: 'Getting started',
+		content: (
+			<p>
+				Install the library with <code>bun add @auldrant/ui</code> and import the stylesheet.
+			</p>
+		),
+		defaultOpen: true,
+	},
+	{
+		id: 'configuration',
+		trigger: 'Configuration',
+		content: (
+			<p>
+				Wrap your app in a <code>&lt;Theme&gt;</code> component to apply design tokens.
+			</p>
+		),
+	},
+	{
+		id: 'customisation',
+		trigger: 'Customisation',
+		content: (
+			<p>
+				Override <code>--aui-base-primary</code> and other base tokens to theme the library.
+			</p>
+		),
+	},
+];
+
+const exclusiveItems: IAccordionItem[] = [
+	{
+		id: 'faq-1',
+		trigger: 'What browsers are supported?',
+		content: <p>All modern browsers — Chrome, Firefox, Safari, and Edge. No IE11 support.</p>,
+	},
+	{
+		id: 'faq-2',
+		trigger: 'Is server-side rendering supported?',
+		content: (
+			<p>
+				Yes. The library uses Preact, which supports SSR via <code>preact-render-to-string</code>.
+			</p>
+		),
+	},
+	{
+		id: 'faq-3',
+		trigger: 'Can I use this with React?',
+		content: (
+			<p>
+				Not directly, but Preact's compatibility layer (<code>preact/compat</code>) allows
+				React-targeted code to use Preact components.
+			</p>
+		),
+	},
+];
+
+const richContentItems: IAccordionItem[] = [
+	{
+		id: 'rich',
+		trigger: 'Panel with rich content',
+		content: (
+			<div>
+				<p>
+					This panel contains a paragraph and a list to verify that the animation handles
+					variable-height content correctly.
+				</p>
+				<ul>
+					<li>First item in the list</li>
+					<li>Second item in the list</li>
+					<li>Third item — a bit longer to push the height up further</li>
+				</ul>
+			</div>
+		),
+		defaultOpen: true,
+	},
+	{
+		id: 'short',
+		trigger: 'Short panel',
+		content: <p>Brief content.</p>,
+	},
+];
+
+export const AccordionSection: FunctionComponent = () => (
+	<div class="dev-section">
+		<h2>Accordion</h2>
+
+		<h3>Multi-expand (default) — first item open</h3>
+		<Accordion items={multiExpandItems} />
+
+		<h3>Exclusive mode (FAQ)</h3>
+		<Accordion items={exclusiveItems} exclusive />
+
+		<h3>Rich content — variable height</h3>
+		<Accordion items={richContentItems} />
+	</div>
+);

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,0 +1,132 @@
+import { useSignal } from '@preact/signals';
+import type { IBaseProps } from '@scripts/types';
+import { cx } from '@scripts/utils';
+import styles from '@styles/Accordion.module.css';
+import { ChevronDown } from 'lucide-preact';
+import type { ComponentChildren, FunctionComponent } from 'preact';
+import { useEffect, useId, useRef } from 'preact/hooks';
+
+/** A single item in an {@link Accordion}. */
+export interface IAccordionItem {
+	/** Stable identifier. Used for aria-controls/aria-labelledby wiring and open-state tracking. */
+	id: string;
+	/** Visible trigger label text. */
+	trigger: string;
+	/** Panel content. Supports arbitrary markup. */
+	content: ComponentChildren;
+	/** Whether this panel is open on initial render. Ignored after mount. */
+	defaultOpen?: boolean;
+}
+
+/** Props for {@link Accordion}. */
+interface IAccordionProps extends IBaseProps {
+	/**
+	 * Accordion items. Each requires a stable `id`, `trigger` label, and `content`.
+	 *
+	 * Note: each expanded panel renders `role="region"`. When many panels can be
+	 * simultaneously open (exclusive=false), landmark proliferation may degrade
+	 * screen reader navigation. Consider limiting item count in that mode.
+	 */
+	items: IAccordionItem[];
+	/**
+	 * When true, opening one panel closes all others.
+	 * Defaults to false (multi-expand).
+	 *
+	 * Note: `defaultOpen` on multiple items is honoured on initial render
+	 * regardless of this flag. Exclusive mode only applies to user-initiated toggles.
+	 */
+	exclusive?: boolean;
+}
+
+interface IAccordionPanelProps {
+	id: string;
+	labelledBy: string;
+	isOpen: boolean;
+	children: ComponentChildren;
+}
+
+const AccordionPanel: FunctionComponent<IAccordionPanelProps> = (props) => {
+	const { id, labelledBy, isOpen, children } = props;
+	const ref = useRef<HTMLElement>(null);
+
+	useEffect(() => {
+		if (ref.current) {
+			ref.current.inert = !isOpen;
+		}
+	}, [isOpen]);
+
+	return (
+		<section ref={ref} id={id} aria-labelledby={labelledBy} class={styles.accordionPanel}>
+			<div class={styles.accordionPanelInner}>{children}</div>
+		</section>
+	);
+};
+
+/**
+ * Collapsible disclosure sections with ARIA state, keyboard support, and smooth animation.
+ * Supports multi-expand (default) and exclusive (single-open) modes.
+ */
+const Accordion: FunctionComponent<IAccordionProps> = (props) => {
+	const { items, exclusive = false, class: className } = props;
+
+	const seenIds = new Set<string>();
+	for (const item of items) {
+		if (seenIds.has(item.id)) {
+			throw new Error(`[Accordion] Duplicate item id: "${item.id}". Item ids must be unique.`);
+		}
+		seenIds.add(item.id);
+	}
+
+	const instanceId = useId();
+	const openIds = useSignal<Set<string>>(
+		new Set(items.filter((item) => item.defaultOpen).map((item) => item.id))
+	);
+
+	function toggleItem(id: string) {
+		const next = new Set(openIds.value);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			if (exclusive) {
+				next.clear();
+			}
+			next.add(id);
+		}
+		openIds.value = next;
+	}
+
+	return (
+		<div class={cx(styles.accordion, className)}>
+			{items.map((item) => {
+				const triggerId = `${instanceId}-trigger-${item.id}`;
+				const panelId = `${instanceId}-panel-${item.id}`;
+				const isOpen = openIds.value.has(item.id);
+
+				return (
+					<div key={item.id} class={cx(styles.accordionItem, isOpen && styles.open)}>
+						<h3 class={styles.accordionHeading}>
+							<button
+								type="button"
+								id={triggerId}
+								class={styles.accordionTrigger}
+								aria-expanded={isOpen ? 'true' : 'false'}
+								aria-controls={panelId}
+								onClick={() => toggleItem(item.id)}
+							>
+								{item.trigger}
+								<span class={styles.accordionTriggerIcon} aria-hidden="true">
+									<ChevronDown size="1em" />
+								</span>
+							</button>
+						</h3>
+						<AccordionPanel id={panelId} labelledBy={triggerId} isOpen={isOpen}>
+							{item.content}
+						</AccordionPanel>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+export default Accordion;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 import '@styles/tokens.css';
 
 // Components
+export type { IAccordionItem } from '@components/Accordion';
+export { default as Accordion } from '@components/Accordion';
 export { AlertVariant, default as Alert } from '@components/Alert';
 export { BadgeVariant, default as Badge } from '@components/Badge';
 export { default as Button } from '@components/Button';

--- a/src/styles/Accordion.module.css
+++ b/src/styles/Accordion.module.css
@@ -1,0 +1,72 @@
+.accordion {
+	display: grid;
+	gap: 0;
+	border: 1px solid var(--aui-color-border);
+	border-radius: 0.25em;
+	overflow: hidden;
+}
+
+.accordion-item {
+	border-top: 1px solid var(--aui-color-border);
+}
+
+.accordion-item:first-child {
+	border-top: none;
+}
+
+.accordion-heading {
+	margin: 0;
+}
+
+.accordion-trigger {
+	composes: focus-ring from "@styles/shared.css";
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	width: 100%;
+	padding: 0.75em 1em;
+	border: none;
+	background: transparent;
+	color: var(--aui-color-text);
+	font: inherit;
+	font-weight: 600;
+	text-align: start;
+	cursor: pointer;
+}
+
+.accordion-trigger:hover {
+	background: var(--aui-color-background-hover);
+}
+
+.accordion-trigger-icon {
+	display: inline-grid;
+	place-items: center;
+}
+
+.open .accordion-trigger-icon {
+	rotate: 180deg;
+}
+
+.accordion-panel {
+	display: grid;
+	grid-template-rows: 0fr;
+}
+
+.open .accordion-panel {
+	grid-template-rows: 1fr;
+}
+
+.accordion-panel-inner {
+	overflow: hidden;
+	padding: 0 1em 0.75em;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.accordion-panel {
+		transition: grid-template-rows 0.2s ease;
+	}
+
+	.accordion-trigger-icon {
+		transition: rotate 0.2s ease;
+	}
+}

--- a/tests/Accordion.test.tsx
+++ b/tests/Accordion.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'bun:test';
+import type { IAccordionItem } from '@components/Accordion';
+import Accordion from '@components/Accordion';
+import { fireEvent, render } from '@testing-library/preact';
+
+const baseItems: IAccordionItem[] = [
+	{ id: 'one', trigger: 'Panel one', content: <p>Content one</p> },
+	{ id: 'two', trigger: 'Panel two', content: <p>Content two</p> },
+	{ id: 'three', trigger: 'Panel three', content: <p>Content three</p> },
+];
+
+describe('Accordion', () => {
+	describe('rendering', () => {
+		it('renders all trigger labels', () => {
+			const { getByRole } = render(<Accordion items={baseItems} />);
+
+			getByRole('button', { name: 'Panel one' });
+			getByRole('button', { name: 'Panel two' });
+			getByRole('button', { name: 'Panel three' });
+		});
+
+		it('forwards the class prop to the root element', () => {
+			const { container } = render(<Accordion items={baseItems} class="custom-class" />);
+
+			expect(container.firstElementChild?.classList.contains('custom-class')).toBe(true);
+		});
+
+		it('throws when two items share the same id', () => {
+			const duplicateItems: IAccordionItem[] = [
+				{ id: 'dup', trigger: 'First', content: 'A' },
+				{ id: 'dup', trigger: 'Second', content: 'B' },
+			];
+
+			expect(() => render(<Accordion items={duplicateItems} />)).toThrow(
+				'[Accordion] Duplicate item id: "dup". Item ids must be unique.'
+			);
+		});
+	});
+
+	describe('initial state', () => {
+		it('all panels are collapsed by default', () => {
+			const { getAllByRole } = render(<Accordion items={baseItems} />);
+
+			const buttons = getAllByRole('button');
+			for (const button of buttons) {
+				expect(button.getAttribute('aria-expanded')).toBe('false');
+			}
+		});
+
+		it('item with defaultOpen is expanded on mount', () => {
+			const items: IAccordionItem[] = [
+				{ id: 'one', trigger: 'Panel one', content: 'Content', defaultOpen: true },
+				{ id: 'two', trigger: 'Panel two', content: 'Content' },
+			];
+			const { getByRole } = render(<Accordion items={items} />);
+
+			expect(getByRole('button', { name: 'Panel one' }).getAttribute('aria-expanded')).toBe('true');
+			expect(getByRole('button', { name: 'Panel two' }).getAttribute('aria-expanded')).toBe(
+				'false'
+			);
+		});
+
+		it('multiple defaultOpen items are all open in multi-expand mode', () => {
+			const items: IAccordionItem[] = [
+				{ id: 'one', trigger: 'Panel one', content: 'Content', defaultOpen: true },
+				{ id: 'two', trigger: 'Panel two', content: 'Content', defaultOpen: true },
+				{ id: 'three', trigger: 'Panel three', content: 'Content' },
+			];
+			const { getByRole } = render(<Accordion items={items} />);
+
+			expect(getByRole('button', { name: 'Panel one' }).getAttribute('aria-expanded')).toBe('true');
+			expect(getByRole('button', { name: 'Panel two' }).getAttribute('aria-expanded')).toBe('true');
+			expect(getByRole('button', { name: 'Panel three' }).getAttribute('aria-expanded')).toBe(
+				'false'
+			);
+		});
+	});
+
+	describe('multi-expand (default)', () => {
+		it('clicking a collapsed trigger expands it', () => {
+			const { getByRole } = render(<Accordion items={baseItems} />);
+			const trigger = getByRole('button', { name: 'Panel one' });
+
+			fireEvent.click(trigger);
+
+			expect(trigger.getAttribute('aria-expanded')).toBe('true');
+		});
+
+		it('clicking an expanded trigger collapses it', () => {
+			const items: IAccordionItem[] = [
+				{ id: 'one', trigger: 'Panel one', content: 'Content', defaultOpen: true },
+			];
+			const { getByRole } = render(<Accordion items={items} />);
+			const trigger = getByRole('button', { name: 'Panel one' });
+
+			fireEvent.click(trigger);
+
+			expect(trigger.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		it('opening one item does not close another', () => {
+			const { getByRole } = render(<Accordion items={baseItems} />);
+
+			fireEvent.click(getByRole('button', { name: 'Panel one' }));
+			fireEvent.click(getByRole('button', { name: 'Panel two' }));
+
+			expect(getByRole('button', { name: 'Panel one' }).getAttribute('aria-expanded')).toBe('true');
+			expect(getByRole('button', { name: 'Panel two' }).getAttribute('aria-expanded')).toBe('true');
+		});
+	});
+
+	describe('exclusive mode', () => {
+		it('opening an item closes all others', () => {
+			const items: IAccordionItem[] = [
+				{ id: 'one', trigger: 'Panel one', content: 'Content', defaultOpen: true },
+				{ id: 'two', trigger: 'Panel two', content: 'Content' },
+				{ id: 'three', trigger: 'Panel three', content: 'Content' },
+			];
+			const { getByRole } = render(<Accordion items={items} exclusive />);
+
+			fireEvent.click(getByRole('button', { name: 'Panel two' }));
+
+			expect(getByRole('button', { name: 'Panel one' }).getAttribute('aria-expanded')).toBe(
+				'false'
+			);
+			expect(getByRole('button', { name: 'Panel two' }).getAttribute('aria-expanded')).toBe('true');
+			expect(getByRole('button', { name: 'Panel three' }).getAttribute('aria-expanded')).toBe(
+				'false'
+			);
+		});
+
+		it('toggling the open item closes it', () => {
+			const items: IAccordionItem[] = [
+				{ id: 'one', trigger: 'Panel one', content: 'Content', defaultOpen: true },
+			];
+			const { getByRole } = render(<Accordion items={items} exclusive />);
+			const trigger = getByRole('button', { name: 'Panel one' });
+
+			fireEvent.click(trigger);
+
+			expect(trigger.getAttribute('aria-expanded')).toBe('false');
+		});
+	});
+
+	describe('ARIA attributes', () => {
+		it('each trigger has aria-controls matching its panel id', () => {
+			const { getAllByRole } = render(<Accordion items={baseItems} />);
+			const buttons = getAllByRole('button');
+			const regions = getAllByRole('region');
+
+			for (let i = 0; i < buttons.length; i++) {
+				const panelId = buttons[i]?.getAttribute('aria-controls');
+				expect(panelId).toBeTruthy();
+				expect(regions[i]?.id).toBe(panelId);
+			}
+		});
+
+		it('each panel has aria-labelledby matching its trigger id', () => {
+			const { getAllByRole } = render(<Accordion items={baseItems} />);
+			const buttons = getAllByRole('button');
+			const regions = getAllByRole('region');
+
+			for (let i = 0; i < regions.length; i++) {
+				const triggerId = regions[i]?.getAttribute('aria-labelledby');
+				expect(triggerId).toBeTruthy();
+				expect(buttons[i]?.id).toBe(triggerId);
+			}
+		});
+
+		it('each panel has role="region"', () => {
+			const { getAllByRole } = render(<Accordion items={baseItems} />);
+			const regions = getAllByRole('region');
+
+			expect(regions).toHaveLength(baseItems.length);
+		});
+
+		it('aria-expanded is always "true" or "false" on every trigger', () => {
+			const { getAllByRole } = render(<Accordion items={baseItems} />);
+			const buttons = getAllByRole('button');
+
+			for (const button of buttons) {
+				const value = button.getAttribute('aria-expanded');
+				expect(value === 'true' || value === 'false').toBe(true);
+			}
+		});
+	});
+
+	describe('panel content', () => {
+		it('content is in the DOM when collapsed', () => {
+			const { getByText } = render(<Accordion items={baseItems} />);
+
+			getByText('Content one');
+			getByText('Content two');
+			getByText('Content three');
+		});
+	});
+});

--- a/tests/a11y/Accordion.a11y.test.tsx
+++ b/tests/a11y/Accordion.a11y.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import type { IAccordionItem } from '@components/Accordion';
+import Accordion from '@components/Accordion';
+import { fireEvent, render } from '@testing-library/preact';
+import { renderAndCheckA11y } from './setup';
+
+const items: IAccordionItem[] = [
+	{
+		id: 'what',
+		trigger: 'What is an accordion?',
+		content: (
+			<p>
+				An accordion is a vertically stacked set of interactive headings that each reveal a section
+				of content.
+			</p>
+		),
+	},
+	{
+		id: 'why',
+		trigger: 'Why use an accordion?',
+		content: (
+			<div>
+				<p>Accordions help manage vertical space by hiding content until the user requests it.</p>
+				<ul>
+					<li>Reduces cognitive load</li>
+					<li>Keeps the page scannable</li>
+				</ul>
+			</div>
+		),
+	},
+	{
+		id: 'when',
+		trigger: 'When should I avoid them?',
+		content: <p>Avoid accordions when users need to compare content across sections frequently.</p>,
+	},
+];
+
+describe('Accordion a11y', () => {
+	it('has no axe violations — all collapsed (baseline)', async () => {
+		await renderAndCheckA11y(<Accordion items={items} />);
+	});
+
+	it('has no axe violations — first item expanded', async () => {
+		const openItems = items.map((item, i) => ({ ...item, defaultOpen: i === 0 }));
+		await renderAndCheckA11y(<Accordion items={openItems} />);
+	});
+
+	it('has no axe violations — exclusive mode, one item open', async () => {
+		const openItems = items.map((item, i) => ({ ...item, defaultOpen: i === 1 }));
+		await renderAndCheckA11y(<Accordion items={openItems} exclusive />);
+	});
+
+	it('WCAG SC 4.1.2: each trigger has an accessible name from its label text', () => {
+		const { getByRole } = render(<Accordion items={items} />);
+
+		getByRole('button', { name: 'What is an accordion?' });
+		getByRole('button', { name: 'Why use an accordion?' });
+		getByRole('button', { name: 'When should I avoid them?' });
+	});
+
+	it('WCAG SC 4.1.2: aria-expanded is present on all triggers', () => {
+		const { getAllByRole } = render(<Accordion items={items} />);
+		const buttons = getAllByRole('button');
+
+		for (const button of buttons) {
+			expect(button.hasAttribute('aria-expanded')).toBe(true);
+		}
+	});
+
+	it('WCAG SC 4.1.2: aria-expanded updates correctly on toggle', () => {
+		const { getByRole } = render(<Accordion items={items} />);
+		const trigger = getByRole('button', { name: 'What is an accordion?' });
+
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+		fireEvent.click(trigger);
+		expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+		fireEvent.click(trigger);
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+	});
+});


### PR DESCRIPTION
## Summary

- Signal-based open state (`Set<string>`) with multi-expand (default) and exclusive (single-open) modes
- CSS `grid-template-rows: 0fr → 1fr` animation — no JS height measurement
- `inert` set imperatively via `useEffect` + ref on collapsed panels to block Tab focus
- `<section aria-labelledby>` panels for correct landmark semantics
- Duplicate item ID validation throws at render time (programming error, not recoverable)
- Behavioral tests (16) + axe-core a11y tests (6) — 22 tests total

## Fixes

Fixes #12

## Test Plan

- [x] `bun test tests/Accordion.test.tsx` — 16 pass
- [x] `bun test tests/a11y/Accordion.a11y.test.tsx` — 6 pass
- [x] `bun run check` — clean (no lint/type errors)
- [x] Full test suite — 438 pass, 0 fail