### PR TITLE
chore: add README badges (npm version, CI, license)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @auldrant/ui
 
+[![npm](https://img.shields.io/npm/v/@auldrant/ui?color=blue)](https://www.npmjs.com/package/@auldrant/ui)
+[![CI](https://img.shields.io/github/actions/workflow/status/coloneljade/auldrant-ui/ci.yml?label=CI)](https://github.com/coloneljade/auldrant-ui/actions)
+[![license](https://img.shields.io/github/license/coloneljade/auldrant-ui)](https://github.com/coloneljade/auldrant-ui/blob/main/LICENSE)
+
 Accessible Preact component library with design tokens and CSS modules.
 
 ## Installation


### PR DESCRIPTION
Closes #136

## Summary
Add shields.io badges to README for npm version, CI status, and license.

## Test Plan
- [ ] Badges render in PR preview
- [ ] Each badge resolves (version shows 1.1.1, CI shows passing, license shows MIT)