### PR TITLE
fix: codebase review remediations (a11y, types, useTimer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] - 2026-04-21
+
+### Changed
+
+- Consolidate cross-cutting types and rename useTimer to named export ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+- Narrow target type to fragment identifier ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+
+### Fixed
+
+- Tie arrow-key activation to eager mount mode ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+- Render disabled prev/next as non-navigable buttons ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+- Consolidate to a single persistent live region ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+- Make fallback wrapper keyboard-focusable ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+- Update useTimer import to named form ([#152](https://github.com/coloneljade/auldrant-ui/pull/152))
+
 ## [2.0.0] - 2026-03-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ This adds the following to your commit message:
 2. Open in DevContainer (recommended) or install [Bun](https://bun.sh/) locally
 3. Run `bun install`
 
+`bun install` runs `prepare` which wires `.githooks/` via `core.hooksPath`. Skipping `bun install` means the `commit-msg` and `pre-push` hooks (sign-off validation, conventional-commit format) won't fire.
+
 ## Code Style
 
 - **Formatter/Linter**: Biome (configured in `biome.json`)
@@ -71,8 +73,8 @@ Run `bun run check` to verify, `bun run check:fix` to auto-fix.
 - Use semantic HTML elements before reaching for ARIA
 - Use CSS modules (`.module.css`) for component styles
 - Use CSS Grid for layout (no flexbox for page/component layout)
-- Use `em` units for spacing and sizing
-- Export all public components from `src/index.ts`
+- Use `em` units for spacing and sizing. `rem` is permitted only on `min-width`/`min-height` of interactive elements to meet WCAG 2.5.5 / 2.5.8 touch-target minimums.
+- Export all public components from `src/components/index.ts` (the components subpath barrel)
 - Test your component on the dev test page (`bun run dev`)
 
 ## Dev Test Page
@@ -113,11 +115,18 @@ Before submitting, all of these must pass:
 
 ### Merging
 
-PRs are merged by the merge bot. A maintainer comments one of:
+PRs are merged by the [merge bot](https://github.com/coloneljade/merge-bot). A maintainer posts a `/merge` comment; the bot determines the version bump from the branch prefix (default map: `feat`/`feature` → minor, `fix` → patch). Other prefixes (`refactor/`, `chore/`, `docs/`, etc.) merge without a version bump.
 
-- `/merge fix` — patch bump (bug fixes, `0.0.x`)
-- `/merge feat` — minor bump (new features, `0.x.0`)
-- `/merge feature` — minor bump (alias for feat)
+Override flags:
+
+- `/merge` — merge with auto-detected bump from branch prefix
+- `/merge --major` — force major bump (explicit opt-in; never inferred)
+- `/merge --minor` — force minor bump
+- `/merge --patch` — force patch bump
+- `/merge --no-bump` — merge without version bump or CHANGELOG entry
+- `/merge --no-squash` — merge commit instead of squash
+
+Flags can be combined: `/merge --patch --no-squash`.
 
 The bot handles CHANGELOG entries and version bumps automatically. Do not edit these manually.
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,14 @@ function App() {
 | `@auldrant/ui/styles` | CSS tokens + component styles (import once in app entry) | `import '@auldrant/ui/styles'` |
 | `@auldrant/ui/components` | All components | `import { Button, Theme } from '@auldrant/ui/components'` |
 | `@auldrant/ui/signals` | All signals | `import { navigate, toast } from '@auldrant/ui/signals'` |
-| `@auldrant/ui/hooks` | Hooks (`useTimer`, `usePage`) | `import useTimer from '@auldrant/ui/hooks'` |
+| `@auldrant/ui/hooks` | Hooks (`useTimer`, `usePage`) | `import { useTimer } from '@auldrant/ui/hooks'` |
 | `@auldrant/ui/utils` | Utilities (`cx`, `HeadingLevel`) | `import { cx } from '@auldrant/ui/utils'` |
 
 > **Note:** Consumer tsconfig must use a `moduleResolution` mode that supports package `exports` (recommended: `"bundler"`).
+>
+> **No root export:** the package intentionally has no `.` entry point — all imports use subpaths. Import from `@auldrant/ui/components`, `@auldrant/ui/signals`, etc. rather than `@auldrant/ui`.
+>
+> **URL props are not sanitized.** Components that accept a URL (`Link.href`, `DownloadLink.href`, `SkipLink.target`, `Alert.actionHref`) forward the value directly to the rendered `<a href>`. Validate any URL derived from untrusted input before passing it to these components.
 
 ## Components
 
@@ -69,7 +73,7 @@ function App() {
 | `Skeleton` | Loading placeholder with shimmer animation. Size via the `class` prop | `rounded?` (pill/avatar shape) |
 | `Toast` + `Toaster` | Transient notification with auto-dismiss and hover/focus pause. Mount `<Toaster />` once in app root; call `toast()` anywhere | `message`, `variant?`, `title?`, `duration?`, `dismissLabel?`, `onDismiss?` on Toast |
 
-> **Note:** Toasts are intentionally transient — content must be safe to miss. For critical errors the user must act on, use `Alert`. All toasts use `role="status"` (polite) and do not interrupt screen reader focus.
+> **Note:** Toasts are intentionally transient — content must be safe to miss. For critical errors the user must act on, use `Alert`. The `Toaster` wrapper is a single polite live region (`aria-live="polite"`); individual toasts are plain content inserted into it, so screen readers announce without duplicate or missed notifications.
 
 ### Form Controls
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auldrant/ui",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "Accessible Preact component library with design tokens and CSS modules",
   "author": "Colonel Jade",

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,6 +1,5 @@
-import type { IDialogAction } from '@internal/DialogBase';
 import DialogBase from '@internal/DialogBase';
-import type { IBaseProps } from '@internal/types';
+import type { IBaseProps, IDialogAction } from '@internal/types';
 import type { ComponentChildren, FunctionComponent } from 'preact';
 
 /** Props for {@link Dialog}. */

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,5 @@
-import type { IDialogAction } from '@internal/DialogBase';
 import DialogBase from '@internal/DialogBase';
-import type { IBaseProps } from '@internal/types';
+import type { IBaseProps, IDialogAction } from '@internal/types';
 import type { ComponentChildren, FunctionComponent } from 'preact';
 
 /** Props for {@link Modal}. */

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -133,15 +133,19 @@ const Pagination: FunctionComponent<IPaginationProps> = (props) => {
 			<nav class={cx(styles.pagination, className)} aria-label="Pagination">
 				<ul class={styles.list}>
 					<li class={styles.item}>
-						<Link
-							href={pageHref(base, prevPage)}
-							class={styles.pageButton}
-							aria-label="Previous page"
-							aria-disabled={isPrevDisabled ? true : undefined}
-							tabIndex={isPrevDisabled ? -1 : undefined}
-						>
-							{prevLabel}
-						</Link>
+						{isPrevDisabled ? (
+							<button type="button" class={styles.pageButton} aria-label="Previous page" disabled>
+								{prevLabel}
+							</button>
+						) : (
+							<Link
+								href={pageHref(base, prevPage)}
+								class={styles.pageButton}
+								aria-label="Previous page"
+							>
+								{prevLabel}
+							</Link>
+						)}
 					</li>
 
 					{items.map((item, i) =>
@@ -169,15 +173,19 @@ const Pagination: FunctionComponent<IPaginationProps> = (props) => {
 					)}
 
 					<li class={styles.item}>
-						<Link
-							href={pageHref(base, nextPage)}
-							class={styles.pageButton}
-							aria-label="Next page"
-							aria-disabled={isNextDisabled ? true : undefined}
-							tabIndex={isNextDisabled ? -1 : undefined}
-						>
-							{nextLabel}
-						</Link>
+						{isNextDisabled ? (
+							<button type="button" class={styles.pageButton} aria-label="Next page" disabled>
+								{nextLabel}
+							</button>
+						) : (
+							<Link
+								href={pageHref(base, nextPage)}
+								class={styles.pageButton}
+								aria-label="Next page"
+							>
+								{nextLabel}
+							</Link>
+						)}
 					</li>
 				</ul>
 			</nav>

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -5,8 +5,8 @@ import type { FunctionComponent } from 'preact';
 
 /** Props for {@link SkipLink}. */
 interface ISkipLinkProps extends IBaseProps {
-	/** Target element ID (including `#`). */
-	target: string;
+	/** Target element ID (must start with `#`). */
+	target: `#${string}`;
 	/** Visible link text. Defaults to `'Skip to main content'`. */
 	label?: string;
 }

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -103,10 +103,15 @@ export const Tab: FunctionComponent<ITabProps> = () => null;
  * Accessible tab interface with ARIA state, keyboard navigation, and lazy panel mounting.
  *
  * Keyboard: ArrowRight/Left navigate tabs with wrapping; Home/End jump to first/last.
- * All navigation auto-activates the focused tab.
+ *
+ * Activation mode follows mount mode (W3C WAI-ARIA APG Tabs pattern):
+ * - `eager: false` (default, lazy mount) — arrow keys move focus only; Enter, Space,
+ *   or click activate. Avoids mounting every panel as the user browses tabs.
+ * - `eager: true` — arrow keys move focus and auto-activate the focused tab. Safe
+ *   because panels are already mounted.
  *
  * Panels are lazy-mounted by default — content renders on first activation and stays
- * mounted. Set `eager` on the group or individual tabs to mount immediately.
+ * mounted.
  */
 const TabGroup: FunctionComponent<ITabGroupProps> = (props) => {
 	const {
@@ -175,6 +180,11 @@ const TabGroup: FunctionComponent<ITabGroupProps> = (props) => {
 		tabs.find((t) => t.props.id === id)?.props.onActivate?.();
 	}
 
+	// Auto-activate on arrow only when tabs are eagerly mounted — otherwise every
+	// arrow keypress would mount the focused tab's panel, defeating lazy mounting.
+	// Per-tab `eager` opts in individually; group `eager` opts in for all.
+	const anyEager = tabs.some((t) => t.props.eager ?? groupEager);
+
 	function handleKeyDown(e: KeyboardEvent) {
 		const tabEls = tablistRef.current
 			? Array.from(tablistRef.current.querySelectorAll<HTMLElement>('[role=tab]'))
@@ -201,7 +211,9 @@ const TabGroup: FunctionComponent<ITabGroupProps> = (props) => {
 			const tabId = targetEl?.dataset.tabId;
 			if (targetEl && tabId) {
 				targetEl.focus();
-				activateTab(tabId);
+				if (anyEager) {
+					activateTab(tabId);
+				}
 			}
 		}
 	}

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -3,15 +3,7 @@ import styles from '@styles/Theme.module.css';
 import { cx } from '@utils';
 import type { ComponentChildren, FunctionComponent } from 'preact';
 
-/** Preset palette class names for `<Theme class={Palette.blue}>`. */
-export enum Palette {
-	blue = 'aui-blue',
-	purple = 'aui-purple',
-	teal = 'aui-teal',
-	red = 'aui-red',
-	orange = 'aui-orange',
-	yellow = 'aui-yellow',
-}
+export { Palette } from '@internal/types';
 
 /** Props for {@link Theme}. */
 interface IThemeProps extends IBaseProps {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,19 +1,14 @@
 import Icon, { IconName } from '@components/Icon';
 import Tooltip from '@components/Tooltip';
-import useTimer from '@hooks';
+import { useTimer } from '@hooks';
+import { ToastVariant } from '@internal/types';
 import type { IBaseProps } from '@internal/types';
 import { useSignal } from '@preact/signals';
 import styles from '@styles/Toast.module.css';
 import { cx } from '@utils';
 import type { FunctionComponent } from 'preact';
 
-/** Severity variants for {@link Toast}. Controls color and leading icon. */
-export enum ToastVariant {
-	info = 'info',
-	success = 'success',
-	warning = 'warning',
-	error = 'error',
-}
+export { ToastVariant } from '@internal/types';
 
 /** Props for {@link Toast}. */
 interface IToastProps extends IBaseProps {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -7,6 +7,7 @@ import { useSignal } from '@preact/signals';
 import styles from '@styles/Toast.module.css';
 import { cx } from '@utils';
 import type { FunctionComponent } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
 
 export { ToastVariant } from '@internal/types';
 
@@ -43,8 +44,9 @@ const variantClass: { [key in ToastVariant]: string | undefined } = {
 /**
  * Individual toast notification. Mount via {@link Toaster} — do not use directly.
  *
- * Always `role="status"` (polite). Toasts are transient; for critical errors
- * the user must act on, use {@link Alert} instead.
+ * Toasts are rendered as plain content inside the Toaster's single polite live region
+ * (a per-toast live region would nest with the wrapper's and cause inconsistent
+ * announcements). Transient — for critical errors the user must act on, use {@link Alert}.
  */
 const Toast: FunctionComponent<IToastProps> = (props) => {
 	const {
@@ -58,6 +60,7 @@ const Toast: FunctionComponent<IToastProps> = (props) => {
 	} = props;
 
 	const dismissing = useSignal(false);
+	const rootRef = useRef<HTMLDivElement>(null);
 
 	const timer = useTimer(duration, () => {
 		dismissing.value = true;
@@ -68,18 +71,37 @@ const Toast: FunctionComponent<IToastProps> = (props) => {
 		dismissing.value = true;
 	}
 
+	// Pause-on-hover / pause-on-focus wired as imperative DOM listeners. The root
+	// <div> is presentational (no role); JSX event handlers on a static element
+	// trigger biome's noStaticElementInteractions — this pattern mirrors Tooltip.tsx.
+	useEffect(() => {
+		const root = rootRef.current;
+		if (!root) {
+			return;
+		}
+		const pause = () => timer.pause();
+		const resume = () => timer.resume();
+		root.addEventListener('mouseenter', pause);
+		root.addEventListener('mouseleave', resume);
+		root.addEventListener('focusin', pause);
+		root.addEventListener('focusout', resume);
+		return () => {
+			root.removeEventListener('mouseenter', pause);
+			root.removeEventListener('mouseleave', resume);
+			root.removeEventListener('focusin', pause);
+			root.removeEventListener('focusout', resume);
+		};
+	}, [timer]);
+
 	return (
-		<output
+		<div
+			ref={rootRef}
 			class={cx(
 				styles.toast,
 				variantClass[variant],
 				dismissing.value && styles.dismissing,
 				className
 			)}
-			onMouseEnter={() => timer.pause()}
-			onMouseLeave={() => timer.resume()}
-			onFocusIn={() => timer.pause()}
-			onFocusOut={() => timer.resume()}
 			onAnimationEnd={(e) => {
 				if (dismissing.value && e.target === e.currentTarget) {
 					onDismiss?.();
@@ -101,7 +123,7 @@ const Toast: FunctionComponent<IToastProps> = (props) => {
 					<Icon name={IconName.dismiss} />
 				</button>
 			</Tooltip>
-		</output>
+		</div>
 	);
 };
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,8 +1,8 @@
 import Icon, { IconName } from '@components/Icon';
 import Tooltip from '@components/Tooltip';
 import { useTimer } from '@hooks';
-import { ToastVariant } from '@internal/types';
 import type { IBaseProps } from '@internal/types';
+import { ToastVariant } from '@internal/types';
 import { useSignal } from '@preact/signals';
 import styles from '@styles/Toast.module.css';
 import { cx } from '@utils';

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -23,10 +23,10 @@ import type { FunctionComponent } from 'preact';
 const Toaster: FunctionComponent = () => {
 	const items = toasts.value;
 
-	if (items.length === 0) {
-		return null;
-	}
-
+	// Wrapper is the single persistent live region — always mounted so new toasts
+	// are inserted into a region that already exists in the DOM. Screen readers
+	// announce content added to a pre-existing live region; content inserted in
+	// the same render that creates the region is commonly missed.
 	return (
 		<div class={styles.toaster} aria-live="polite" aria-atomic="false">
 			{items.map((item) => (

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -121,12 +121,23 @@ const Tooltip: FunctionComponent<ITooltipProps> = (props) => {
 	}, [isVisible.value]);
 
 	// Inject aria-describedby into the child element if it is a single VNode;
-	// otherwise wrap in a span so the attribute is still applied.
-	const trigger = isValidElement(children)
-		? cloneElement(children as VNode<{ 'aria-describedby'?: string }>, {
-				'aria-describedby': tooltipId,
-			})
-		: ((<span aria-describedby={tooltipId}>{children}</span>) as ComponentChildren);
+	// otherwise wrap in a focusable span so keyboard users can reveal the tooltip.
+	// WCAG 1.4.13 requires tooltips to be discoverable on focus, not only on hover —
+	// without tabIndex, a non-VNode child (plain text, fragment) would produce a
+	// tooltip that is inaccessible to keyboard users.
+	let trigger: ComponentChildren;
+	if (isValidElement(children)) {
+		trigger = cloneElement(children as VNode<{ 'aria-describedby'?: string }>, {
+			'aria-describedby': tooltipId,
+		});
+	} else {
+		trigger = (
+			// biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 1.4.13 — fallback span must be focusable so keyboard users can reveal the tooltip on non-VNode children
+			<span tabIndex={0} aria-describedby={tooltipId}>
+				{children}
+			</span>
+		);
+	}
 
 	return (
 		<span ref={wrapperRef} class={cx(styles.tooltip, className)} data-placement="above">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-export { default as text } from '../styles/text.module.css';
+export { default as text } from '@styles/text.module.css';
 export { AccordionItem, default as Accordion } from './Accordion';
 export { AlertVariant, default as Alert } from './Alert';
 export { BadgeVariant, default as Badge } from './Badge';

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -65,7 +65,7 @@ export interface ITimerControls {
  * state that survives renders without causing them. Only the component's own
  * `dismissing` boolean (or equivalent) needs to trigger a render.
  */
-function useTimer(duration: number, onComplete: () => void): ITimerControls {
+export function useTimer(duration: number, onComplete: () => void): ITimerControls {
 	const remainingRef = useRef<number>(duration);
 	const startRef = useRef<number | null>(null);
 	const handleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -111,5 +111,3 @@ function useTimer(duration: number, onComplete: () => void): ITimerControls {
 
 	return controlsRef.current;
 }
-
-export default useTimer;

--- a/src/internal/DialogBase.tsx
+++ b/src/internal/DialogBase.tsx
@@ -1,25 +1,11 @@
 import Icon, { IconName } from '@components/Icon';
 import Tooltip from '@components/Tooltip';
-import type { IBaseProps } from '@internal/types';
+import type { IBaseProps, IDialogAction } from '@internal/types';
 import useDraggable from '@internal/useDraggable';
 import styles from '@styles/Dialog.module.css';
 import { cx } from '@utils';
 import type { ComponentChildren, FunctionComponent } from 'preact';
 import { useEffect, useId, useRef } from 'preact/hooks';
-
-/** Action button metadata. All fields required to enforce a11y-complete definitions. */
-export interface IDialogAction {
-	/** Button label text. */
-	label: string;
-	/** Accessible description. Rendered as native `title` tooltip. */
-	description: string;
-	/** Click handler. */
-	onClick: () => void;
-	/** Keyboard shortcut string. Single key ('d') or combo ('Shift+D', 'Ctrl+Enter').
-	 *  Parsed internally and wired to a keydown listener while the dialog is open.
-	 *  Displayed visually on the button as a hint. */
-	shortcut: string;
-}
 
 /** Props for {@link DialogBase}. */
 interface IDialogBaseProps extends IBaseProps {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -17,3 +17,35 @@ export interface IFieldProps extends IBaseProps {
 	/** Error message. When set, renders an error message and marks the field as invalid. */
 	error?: string;
 }
+
+/** Preset palette class names for `<Theme class={Palette.blue}>`. */
+export enum Palette {
+	blue = 'aui-blue',
+	purple = 'aui-purple',
+	teal = 'aui-teal',
+	red = 'aui-red',
+	orange = 'aui-orange',
+	yellow = 'aui-yellow',
+}
+
+/** Severity variants for Toast and Alert. Controls color and leading icon. */
+export enum ToastVariant {
+	info = 'info',
+	success = 'success',
+	warning = 'warning',
+	error = 'error',
+}
+
+/** Action button metadata for Dialog/Modal. All fields required to enforce a11y-complete definitions. */
+export interface IDialogAction {
+	/** Button label text. */
+	label: string;
+	/** Accessible description. Rendered as native `title` tooltip. */
+	description: string;
+	/** Click handler. */
+	onClick: () => void;
+	/** Keyboard shortcut string. Single key ('d') or combo ('Shift+D', 'Ctrl+Enter').
+	 *  Parsed internally and wired to a keydown listener while the dialog is open.
+	 *  Displayed visually on the button as a hint. */
+	shortcut: string;
+}

--- a/src/signals/dialogs.ts
+++ b/src/signals/dialogs.ts
@@ -1,4 +1,4 @@
-import type { IDialogAction } from '@internal/DialogBase';
+import type { IDialogAction } from '@internal/types';
 import { signal } from '@preact/signals';
 import type { ComponentChildren } from 'preact';
 

--- a/src/signals/theme.ts
+++ b/src/signals/theme.ts
@@ -1,4 +1,4 @@
-import type { Palette } from '@components/Theme';
+import type { Palette } from '@internal/types';
 import { signal } from '@preact/signals';
 
 /** Currently active palette class. Set to change the theme library-wide. */

--- a/src/signals/toasts.ts
+++ b/src/signals/toasts.ts
@@ -1,4 +1,4 @@
-import type { ToastVariant } from '@components/Toast';
+import type { ToastVariant } from '@internal/types';
 import { signal } from '@preact/signals';
 
 /** A single toast item in the queue. */

--- a/tests/Tabs.test.tsx
+++ b/tests/Tabs.test.tsx
@@ -162,8 +162,9 @@ describe('TabGroup', () => {
 		});
 	});
 
-	describe('keyboard navigation', () => {
-		it('ArrowRight moves focus to the next tab and activates it', () => {
+	describe('keyboard navigation (lazy mode — focus only)', () => {
+		it('ArrowRight moves focus without activating the target tab', () => {
+			// Arrange
 			const { getByRole } = render(
 				<TabGroup>
 					<Tab id="a" label="A">
@@ -180,13 +181,17 @@ describe('TabGroup', () => {
 			const tabA = getByRole('tab', { name: 'A' });
 			const tabB = getByRole('tab', { name: 'B' });
 
+			// Act
 			fireEvent.keyDown(tabA, { key: 'ArrowRight' });
 
+			// Assert — focus moves but activation stays on A (APG manual-activation for lazy panels)
 			expect(document.activeElement).toBe(tabB);
-			expect(tabB.getAttribute('aria-selected')).toBe('true');
+			expect(tabB.getAttribute('aria-selected')).toBe('false');
+			expect(tabA.getAttribute('aria-selected')).toBe('true');
 		});
 
-		it('ArrowLeft moves focus to the previous tab and activates it', () => {
+		it('ArrowLeft moves focus without activating the target tab', () => {
+			// Arrange
 			const { getByRole } = render(
 				<TabGroup defaultActive="b">
 					<Tab id="a" label="A">
@@ -200,10 +205,36 @@ describe('TabGroup', () => {
 			const tabA = getByRole('tab', { name: 'A' });
 			const tabB = getByRole('tab', { name: 'B' });
 
+			// Act
 			fireEvent.keyDown(tabB, { key: 'ArrowLeft' });
 
+			// Assert — focus moves but B stays selected
 			expect(document.activeElement).toBe(tabA);
-			expect(tabA.getAttribute('aria-selected')).toBe('true');
+			expect(tabA.getAttribute('aria-selected')).toBe('false');
+			expect(tabB.getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('eager mode auto-activates on arrow navigation', () => {
+			// Arrange
+			const { getByRole } = render(
+				<TabGroup eager>
+					<Tab id="a" label="A">
+						Content A
+					</Tab>
+					<Tab id="b" label="B">
+						Content B
+					</Tab>
+				</TabGroup>
+			);
+			const tabA = getByRole('tab', { name: 'A' });
+			const tabB = getByRole('tab', { name: 'B' });
+
+			// Act
+			fireEvent.keyDown(tabA, { key: 'ArrowRight' });
+
+			// Assert — eager panels are already mounted, so auto-activation is safe
+			expect(document.activeElement).toBe(tabB);
+			expect(tabB.getAttribute('aria-selected')).toBe('true');
 		});
 
 		it('ArrowRight from last tab wraps to first', () => {
@@ -583,7 +614,29 @@ describe('TabGroup', () => {
 			expect(onActivate).toHaveBeenCalledTimes(1);
 		});
 
-		it('calls onChange on keyboard navigation', () => {
+		it('calls onChange on keyboard navigation in eager mode', () => {
+			// Arrange
+			const onChange = mock(() => {});
+			const { getByRole } = render(
+				<TabGroup eager onChange={onChange}>
+					<Tab id="a" label="A">
+						Content A
+					</Tab>
+					<Tab id="b" label="B">
+						Content B
+					</Tab>
+				</TabGroup>
+			);
+
+			// Act
+			fireEvent.keyDown(getByRole('tab', { name: 'A' }), { key: 'ArrowRight' });
+
+			// Assert
+			expect(onChange).toHaveBeenCalledWith('b');
+		});
+
+		it('does not call onChange on arrow navigation in lazy mode', () => {
+			// Arrange
 			const onChange = mock(() => {});
 			const { getByRole } = render(
 				<TabGroup onChange={onChange}>
@@ -596,9 +649,11 @@ describe('TabGroup', () => {
 				</TabGroup>
 			);
 
+			// Act — arrow moves focus only; no activation means no onChange
 			fireEvent.keyDown(getByRole('tab', { name: 'A' }), { key: 'ArrowRight' });
 
-			expect(onChange).toHaveBeenCalledWith('b');
+			// Assert
+			expect(onChange).not.toHaveBeenCalled();
 		});
 	});
 

--- a/tests/a11y/dialog.a11y.test.tsx
+++ b/tests/a11y/dialog.a11y.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import Dialog from '@components/Dialog';
-import type { IDialogAction } from '@components/DialogBase';
 import Modal from '@components/Modal';
+import type { IDialogAction } from '@internal/types';
 import { render } from '@testing-library/preact';
 import { checkA11y, expectNoViolations, renderAndCheckA11y } from './setup';
 

--- a/tests/a11y/pagination.a11y.test.tsx
+++ b/tests/a11y/pagination.a11y.test.tsx
@@ -62,8 +62,8 @@ describe('Pagination a11y', () => {
 		expect(current?.tagName.toLowerCase()).toBe('span');
 	});
 
-	// WCAG SC 4.1.2: disabled state is exposed to AT via aria-disabled
-	it('disabled prev/next have aria-disabled="true"', () => {
+	// WCAG SC 4.1.2: disabled state is exposed to AT and controls are non-actionable
+	it('disabled prev is a non-link button with native disabled state', () => {
 		// First page — prev is disabled
 		const { getByRole } = render(
 			<Pagination totalPages={10}>
@@ -71,7 +71,8 @@ describe('Pagination a11y', () => {
 			</Pagination>
 		);
 
-		expect(getByRole('link', { name: 'Previous page' }).getAttribute('aria-disabled')).toBe('true');
+		const prev = getByRole('button', { name: 'Previous page' }) as HTMLButtonElement;
+		expect(prev.disabled).toBe(true);
 	});
 
 	// WCAG SC 4.1.2: all interactive controls must have accessible names

--- a/tests/a11y/toast.a11y.test.tsx
+++ b/tests/a11y/toast.a11y.test.tsx
@@ -16,15 +16,8 @@ describe('Toast a11y', () => {
 		);
 	});
 
-	it('WCAG SC 4.1.3: all variants use role="status" (polite)', () => {
-		for (const variant of Object.values(ToastVariant)) {
-			const { getByRole, unmount } = render(
-				<Toast variant={variant} message={`${variant} toast`} onDismiss={() => {}} />
-			);
-			getByRole('status');
-			unmount();
-		}
-	});
+	// Toast is plain content inside Toaster's single persistent live region — the
+	// live region semantics live on the wrapper, not per-toast. See Toaster.a11y.
 
 	it('WCAG SC 4.1.2: dismiss button has an accessible name', () => {
 		const { getByRole } = render(<Toast message="Test" onDismiss={() => {}} />);

--- a/tests/dialog.test.tsx
+++ b/tests/dialog.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test';
 import Dialog from '@components/Dialog';
-import type { IDialogAction } from '@components/DialogBase';
+import type { IDialogAction } from '@internal/types';
 import { fireEvent, render } from '@testing-library/preact';
 
 describe('Dialog', () => {

--- a/tests/modal.test.tsx
+++ b/tests/modal.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test';
-import type { IDialogAction } from '@components/DialogBase';
 import Modal from '@components/Modal';
+import type { IDialogAction } from '@internal/types';
 import { fireEvent, render } from '@testing-library/preact';
 
 const defaultAction: IDialogAction = {

--- a/tests/pagination.test.tsx
+++ b/tests/pagination.test.tsx
@@ -88,37 +88,29 @@ describe('Pagination', () => {
 		}
 	});
 
-	it('prev link is disabled at page 1', () => {
+	it('disabled prev renders as a disabled button at page 1', () => {
 		// Arrange — page 1 (base URL)
 
 		// Act
-		const { getByRole } = render(<Pagination totalPages={10}>content</Pagination>);
+		const { getByRole, queryByRole } = render(<Pagination totalPages={10}>content</Pagination>);
 
-		// Assert
-		const prev = getByRole('link', { name: 'Previous page' });
-		expect(prev.getAttribute('aria-disabled')).toBe('true');
-		expect(prev.getAttribute('tabindex')).toBe('-1');
+		// Assert — disabled prev is a <button disabled>, not a link
+		const prev = getByRole('button', { name: 'Previous page' }) as HTMLButtonElement;
+		expect(prev.disabled).toBe(true);
+		expect(queryByRole('link', { name: 'Previous page' })).toBeNull();
 	});
 
-	it('prev link href is clamped to page 1 when disabled', () => {
-		// Act
-		const { getByRole } = render(<Pagination totalPages={10}>content</Pagination>);
-
-		// Assert — href stays at base (page 1)
-		expect(getByRole('link', { name: 'Previous page' }).getAttribute('href')).toBe('/results');
-	});
-
-	it('next link is disabled at last page', () => {
+	it('disabled next renders as a disabled button at last page', () => {
 		// Arrange — last page
 		location.value = '/results/page/10';
 
 		// Act
-		const { getByRole } = render(<Pagination totalPages={10}>content</Pagination>);
+		const { getByRole, queryByRole } = render(<Pagination totalPages={10}>content</Pagination>);
 
 		// Assert
-		const next = getByRole('link', { name: 'Next page' });
-		expect(next.getAttribute('aria-disabled')).toBe('true');
-		expect(next.getAttribute('tabindex')).toBe('-1');
+		const next = getByRole('button', { name: 'Next page' }) as HTMLButtonElement;
+		expect(next.disabled).toBe(true);
+		expect(queryByRole('link', { name: 'Next page' })).toBeNull();
 	});
 
 	it('page 1 href is base URL', () => {
@@ -145,6 +137,9 @@ describe('Pagination', () => {
 	});
 
 	it('supports custom prevLabel and nextLabel', () => {
+		// Arrange — non-first, non-last page so both prev and next are enabled links
+		location.value = '/results/page/3';
+
 		// Act
 		const { getByRole } = render(
 			<Pagination totalPages={5} prevLabel="← Back" nextLabel="Forward →">
@@ -162,8 +157,10 @@ describe('Pagination', () => {
 		const { getByRole } = render(<Pagination totalPages={1}>content</Pagination>);
 
 		// Assert
-		expect(getByRole('link', { name: 'Previous page' }).getAttribute('aria-disabled')).toBe('true');
-		expect(getByRole('link', { name: 'Next page' }).getAttribute('aria-disabled')).toBe('true');
+		const prev = getByRole('button', { name: 'Previous page' }) as HTMLButtonElement;
+		const next = getByRole('button', { name: 'Next page' }) as HTMLButtonElement;
+		expect(prev.disabled).toBe(true);
+		expect(next.disabled).toBe(true);
 	});
 
 	it('page 1 of 10 renders first 3 pages and last page with ellipsis', () => {

--- a/tests/smoke/smoke.tsx
+++ b/tests/smoke/smoke.tsx
@@ -10,7 +10,7 @@ import {
 	Palette,
 	Theme,
 } from '@auldrant/ui/components';
-import useTimer, { type ITimerControls, page, usePage } from '@auldrant/ui/hooks';
+import { type ITimerControls, page, usePage, useTimer } from '@auldrant/ui/hooks';
 import {
 	confirm,
 	dialog,

--- a/tests/toast.test.tsx
+++ b/tests/toast.test.tsx
@@ -1,36 +1,8 @@
 import { describe, expect, it, mock } from 'bun:test';
-import Toast, { ToastVariant } from '@components/Toast';
+import Toast from '@components/Toast';
 import { act, fireEvent, render } from '@testing-library/preact';
 
 describe('Toast', () => {
-	describe('ARIA role', () => {
-		it('renders role="status" for the default (info) variant', () => {
-			const { getByRole } = render(<Toast message="Info" onDismiss={() => {}} />);
-			getByRole('status');
-		});
-
-		it('renders role="status" for the success variant', () => {
-			const { getByRole } = render(
-				<Toast variant={ToastVariant.success} message="Done" onDismiss={() => {}} />
-			);
-			getByRole('status');
-		});
-
-		it('renders role="status" for the warning variant', () => {
-			const { getByRole } = render(
-				<Toast variant={ToastVariant.warning} message="Warning" onDismiss={() => {}} />
-			);
-			getByRole('status');
-		});
-
-		it('renders role="status" for the error variant', () => {
-			const { getByRole } = render(
-				<Toast variant={ToastVariant.error} message="Error" onDismiss={() => {}} />
-			);
-			getByRole('status');
-		});
-	});
-
 	describe('content', () => {
 		it('renders the message text', () => {
 			const { getByText } = render(<Toast message="Hello world" onDismiss={() => {}} />);
@@ -75,7 +47,8 @@ describe('Toast', () => {
 	});
 
 	// Bun 1.3.x has no mock.timers API. We replace global.setTimeout with a stub
-	// that captures the callback and delay, then manually invoke it.
+	// that captures the callback and delay, then manually invoke it. try/finally
+	// ensures a failed assertion doesn't leak stubbed globals into other tests.
 	describe('auto-dismiss timer', () => {
 		it('calls onDismiss after the specified duration', () => {
 			let capturedCallback: (() => void) | null = null;
@@ -87,19 +60,22 @@ describe('Toast', () => {
 				return 0;
 			}) as unknown as typeof setTimeout;
 
-			const onDismiss = mock(() => {});
-			const { container } = render(
-				<Toast message="Auto-dismiss" duration={3000} onDismiss={onDismiss} />
-			);
+			try {
+				const onDismiss = mock(() => {});
+				const { container } = render(
+					<Toast message="Auto-dismiss" duration={3000} onDismiss={onDismiss} />
+				);
 
-			expect(capturedDelay).toBe(3000);
-			act(() => {
-				capturedCallback?.();
-			});
-			fireEvent.animationEnd(container.firstElementChild as HTMLElement);
+				expect(capturedDelay).toBe(3000);
+				act(() => {
+					capturedCallback?.();
+				});
+				fireEvent.animationEnd(container.firstElementChild as HTMLElement);
 
-			expect(onDismiss).toHaveBeenCalledTimes(1);
-			global.setTimeout = origSetTimeout;
+				expect(onDismiss).toHaveBeenCalledTimes(1);
+			} finally {
+				global.setTimeout = origSetTimeout;
+			}
 		});
 
 		it('pauses timer on mouse enter and resumes on mouse leave', () => {
@@ -112,24 +88,26 @@ describe('Toast', () => {
 			}) as unknown as typeof setTimeout;
 			global.clearTimeout = ((_handle: unknown) => {}) as unknown as typeof clearTimeout;
 
-			const { container } = render(
-				<Toast message="Hover pause" duration={5000} onDismiss={() => {}} />
-			);
+			try {
+				const { container } = render(
+					<Toast message="Hover pause" duration={5000} onDismiss={() => {}} />
+				);
 
-			// Timer started — one timeout queued
-			expect(timeouts.length).toBe(1);
+				// Timer started — one timeout queued
+				expect(timeouts.length).toBe(1);
 
-			// Hover pauses (clearTimeout called), leave resumes (new setTimeout queued)
-			fireEvent.mouseEnter(container.firstElementChild as HTMLElement);
-			fireEvent.mouseLeave(container.firstElementChild as HTMLElement);
+				// Hover pauses (clearTimeout called), leave resumes (new setTimeout queued)
+				fireEvent.mouseEnter(container.firstElementChild as HTMLElement);
+				fireEvent.mouseLeave(container.firstElementChild as HTMLElement);
 
-			// A new timeout should have been queued for the resumed timer
-			expect(timeouts.length).toBe(2);
-			// Resumed delay should be <= original duration (remaining time)
-			expect(timeouts[1]?.delay).toBeLessThanOrEqual(5000);
-
-			global.setTimeout = origSetTimeout;
-			global.clearTimeout = origClearTimeout;
+				// A new timeout should have been queued for the resumed timer
+				expect(timeouts.length).toBe(2);
+				// Resumed delay should be <= original duration (remaining time)
+				expect(timeouts[1]?.delay).toBeLessThanOrEqual(5000);
+			} finally {
+				global.setTimeout = origSetTimeout;
+				global.clearTimeout = origClearTimeout;
+			}
 		});
 	});
 

--- a/tests/toaster.test.tsx
+++ b/tests/toaster.test.tsx
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import Toaster from '@components/Toaster';
-import { toast } from '@signals/toasts';
+import { toast, toasts } from '@signals/toasts';
 import { act, fireEvent, render } from '@testing-library/preact';
 
 describe('Toaster', () => {
+	// Module-level signal leaks between tests unless explicitly reset.
+	afterEach(() => {
+		toasts.value = [];
+	});
+
 	it('renders toast messages from the signal', async () => {
 		// Arrange
 		const message = 'Toaster-render-test';
@@ -18,7 +23,7 @@ describe('Toaster', () => {
 		getByText(message);
 	});
 
-	it('renders a polite live region container', async () => {
+	it('wrapper is the persistent polite live region', async () => {
 		// Arrange
 		await act(async () => {
 			toast('Live-region-test');
@@ -33,22 +38,31 @@ describe('Toaster', () => {
 		expect(region?.getAttribute('aria-atomic')).toBe('false');
 	});
 
+	it('wrapper is mounted even when the toast queue is empty', () => {
+		// Act — render with no toasts queued
+		const { container } = render(<Toaster />);
+
+		// Assert — wrapper exists so subsequent toasts insert into a pre-existing live region
+		const region = container.querySelector('[aria-live="polite"]');
+		expect(region).not.toBeNull();
+		expect(region?.children.length).toBe(0);
+	});
+
 	it('removes toast on dismiss callback', async () => {
 		// Arrange
 		const message = 'Toaster-dismiss-test';
 		await act(async () => {
 			toast(message);
 		});
-		const { queryByText, getAllByRole } = render(<Toaster />);
+		const { queryByText, getByRole, container } = render(<Toaster />);
 		expect(queryByText(message)).not.toBeNull();
 
-		// Find the status element containing our specific message
-		const statuses = getAllByRole('status');
-		const target = statuses.find((el) => el.textContent?.includes(message)) as HTMLElement;
-		expect(target).toBeDefined();
+		// The toast is the first child of the aria-live wrapper
+		const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+		const target = region.firstElementChild as HTMLElement;
 
 		// Act — click dismiss then fire animationEnd to trigger onDismiss
-		const dismissBtn = target.querySelector('button[aria-label="Dismiss"]') as HTMLElement;
+		const dismissBtn = getByRole('button', { name: 'Dismiss' });
 		await act(async () => {
 			fireEvent.click(dismissBtn);
 			fireEvent.animationEnd(target);


### PR DESCRIPTION
## Summary

Addresses findings from a full codebase review — four accessibility bugs plus a type-layering refactor and a hook-export rename. The `useTimer` default→named export is a public API change: consumers update `import useTimer from '@auldrant/ui/hooks'` → `import { useTimer } …`. User has requested this land as a minor version bump — use `/merge --minor` at merge time rather than the default patch from the `fix/` branch prefix.

### Fixed

- `Tabs` arrow-key navigation now moves focus only in lazy (default) mode; Enter/Space/click activate. Eager mode keeps auto-activation. Tied to the existing `eager` prop — no new API (Fixes #148)
- Disabled `Pagination` prev/next render as native `<button disabled>` instead of `<a href>` with `aria-disabled`; keyboard users can no longer navigate to non-existent pages via Enter (Fixes #149)
- `Toaster` is now the single persistent polite live region; `Toast` is plain content inside it (no per-toast `<output>`/nested `role="status"`). Wrapper is always mounted so announcements fire reliably (Fixes #150)
- `Tooltip` fallback wrapper gets `tabIndex={0}` so keyboard users can reveal tooltips when children aren't a single VNode — WCAG 1.4.13 (Fixes #151)

### Changed

- Consolidate `Palette`, `ToastVariant`, and `IDialogAction` in `src/internal/types.ts` alongside existing `IBaseProps`/`IFieldProps`. `@signals/*` no longer imports enums from `@components/*`; `@internal/DialogBase` no longer owns a type consumed from `@signals/dialogs`. Public enums are re-exported from `Theme.tsx`/`Toast.tsx` so consumers see no change.
- Rename `useTimer` from default to named export for consistency with the rest of `src/hooks.ts`. **Public API change** — see summary.
- Narrow `SkipLink.target` type from `string` to `` `#${string}` `` to enforce the fragment-identifier invariant at compile time.
- Fix `src/components/index.ts` to use the `@styles/...` alias instead of `../styles/...`.

### Documentation

- `CONTRIBUTING.md`: replace outdated `/merge fix|feat` command list with the authoritative merge-bot flags (including `--major` opt-in and `--no-bump`/`--no-squash`); note `.githooks/` is wired by `bun install`; clarify `rem` exception for WCAG touch-target minimums; fix stale `src/index.ts` reference to `src/components/index.ts`.
- `README.md`: document the intentional no-root-export subpath-only model; note that URL-accepting props (`Link.href`, `DownloadLink.href`, `SkipLink.target`, `Alert.actionHref`) are not sanitized — consumers validate untrusted URLs; update the `useTimer` import example to named; rewrite the Toast note to reflect the single-LR model.

## Test Plan

- [x] \`bun run check\` — Biome lint/format clean (254 files)
- [x] \`bun run typecheck\` — strict TS clean
- [x] \`bun test\` — 844 pass, 0 fail across 93 files
- [x] \`bun run build\` — succeeds; bundle sizes unchanged
- [ ] Spot-check Tabs keyboard nav in dev app: arrow moves focus without activating in lazy mode; Enter/Space/click activates; \`eager\` group auto-activates
- [ ] Spot-check Pagination at page 1 and last page — prev/next buttons are disabled and non-actionable
- [ ] Spot-check Toaster with screen reader if available (VoiceOver/NVDA) — first toast after empty queue announces

## Notes for Reviewers

- The plan, verification, and commit groupings are in the [stored plan file](https://github.com/coloneljade/auldrant-ui/blob/fix/codebase-review-remediation/.claude/plans/cheeky-scribbling-flamingo.md) if useful for context — not for merge.
- Dropped findings as false positives after verification: `SearchInput` focus-ring (already composed via `shared.css`), `Dialog` focus restoration (native `<dialog>.close()` restores per WHATWG spec), `Chip` Backspace/Delete handler (intentional UX, doesn't shadow browser back on focused button), `Link` URL scheme validation (library trusts consumers with URL props).
- `useTimer` default→named normally warrants a major version, but user has explicitly overridden to minor. Ensure the merge is \`/merge --minor\`.