### PR TITLE
feat(tabs,accordion): typed icon prop on Tab and AccordionItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.0] - 2026-05-03
+
+### Added
+
+- Typed icon prop on Tab and AccordionItem ([#155](https://github.com/coloneljade/auldrant-ui/pull/155))
+
 ## [2.2.0] - 2026-05-03
 
 ### Added

--- a/dev/TestPage.tsx
+++ b/dev/TestPage.tsx
@@ -44,6 +44,7 @@ import { SelectSection } from './sections/SelectSection';
 import { SkeletonSection } from './sections/SkeletonSection';
 import { SpinnerSection } from './sections/SpinnerSection';
 import { TableSection } from './sections/TableSection';
+import { TabsSection } from './sections/TabsSection';
 import { TextareaSection } from './sections/TextareaSection';
 import { ToastSection } from './sections/ToastSection';
 import { ToggleSection } from './sections/ToggleSection';
@@ -76,6 +77,7 @@ const ALL_SECTIONS: { key: string; Section: FunctionComponent }[] = [
 	{ key: 'routing', Section: RoutingSection },
 	{ key: 'form', Section: FormDemo },
 	{ key: 'accordion', Section: AccordionSection },
+	{ key: 'tabs', Section: TabsSection },
 	{ key: 'dialog', Section: DialogSection },
 	{ key: 'dialoghost', Section: DialogHostSection },
 	{ key: 'dropdown', Section: DropdownSection },
@@ -220,6 +222,7 @@ export const TestPage: FunctionComponent = () => {
 									</Tab>
 									<Tab id="disclosure" label="Disclosure">
 										<AccordionSection />
+										<TabsSection />
 									</Tab>
 									<Tab id="overlay" label="Overlay">
 										<DialogSection />

--- a/dev/sections/AccordionSection.tsx
+++ b/dev/sections/AccordionSection.tsx
@@ -1,4 +1,5 @@
 import Accordion, { AccordionItem } from '@components/Accordion';
+import { IconName } from '@components/Icon';
 import type { FunctionComponent } from 'preact';
 
 export const AccordionSection: FunctionComponent = () => (
@@ -39,6 +40,32 @@ export const AccordionSection: FunctionComponent = () => (
 					Not directly, but Preact's compatibility layer (<code>preact/compat</code>) allows
 					React-targeted code to use Preact components.
 				</p>
+			</AccordionItem>
+		</Accordion>
+
+		<h3>With icons — every item</h3>
+		<Accordion>
+			<AccordionItem id="icon-status" label="Status" icon={IconName.info} defaultOpen>
+				<p>Informational status message.</p>
+			</AccordionItem>
+			<AccordionItem id="icon-warnings" label="Warnings" icon={IconName.warning}>
+				<p>Warning details.</p>
+			</AccordionItem>
+			<AccordionItem id="icon-settings" label="Settings" icon={IconName.settings}>
+				<p>Settings configuration panel.</p>
+			</AccordionItem>
+		</Accordion>
+
+		<h3>Mixed — some items have icons, some don't</h3>
+		<Accordion>
+			<AccordionItem id="mixed-plain" label="Plain item">
+				<p>No icon.</p>
+			</AccordionItem>
+			<AccordionItem id="mixed-icon" label="With icon" icon={IconName.search}>
+				<p>This item has a leading icon.</p>
+			</AccordionItem>
+			<AccordionItem id="mixed-plain-2" label="Another plain item">
+				<p>Also no icon.</p>
 			</AccordionItem>
 		</Accordion>
 

--- a/dev/sections/TabsSection.tsx
+++ b/dev/sections/TabsSection.tsx
@@ -1,0 +1,48 @@
+import { IconName } from '@components/Icon';
+import TabGroup, { Tab } from '@components/Tabs';
+import type { FunctionComponent } from 'preact';
+
+export const TabsSection: FunctionComponent = () => (
+	<div class="dev-section">
+		<h2>Tabs</h2>
+
+		<h3>Default — text labels</h3>
+		<TabGroup>
+			<Tab id="overview" label="Overview">
+				<p>Overview content.</p>
+			</Tab>
+			<Tab id="details" label="Details">
+				<p>Details content.</p>
+			</Tab>
+			<Tab id="advanced" label="Advanced">
+				<p>Advanced content.</p>
+			</Tab>
+		</TabGroup>
+
+		<h3>With icons — every tab labelled</h3>
+		<TabGroup>
+			<Tab id="search" label="Search" icon={IconName.search}>
+				<p>Search results would go here.</p>
+			</Tab>
+			<Tab id="settings" label="Settings" icon={IconName.settings}>
+				<p>Settings panel.</p>
+			</Tab>
+			<Tab id="quick" label="Quick actions" icon={IconName.zap}>
+				<p>Quick actions panel.</p>
+			</Tab>
+		</TabGroup>
+
+		<h3>Mixed — some tabs have icons, some don't</h3>
+		<TabGroup>
+			<Tab id="docs" label="Documentation">
+				<p>Docs content.</p>
+			</Tab>
+			<Tab id="warnings" label="Warnings" icon={IconName.warning}>
+				<p>Warnings list.</p>
+			</Tab>
+			<Tab id="info" label="Info">
+				<p>Info content.</p>
+			</Tab>
+		</TabGroup>
+	</div>
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auldrant/ui",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "description": "Accessible Preact component library with design tokens and CSS modules",
   "author": "Colonel Jade",

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -19,6 +19,8 @@ interface IAccordionItemProps extends IBaseProps {
 	id: string;
 	/** Visible trigger label text. */
 	label: string;
+	/** Optional leading icon rendered before the label. */
+	icon?: IconName;
 	/** Panel content. Supports arbitrary markup. */
 	children: ComponentChildren;
 	/** Whether this panel is open on initial render. Ignored after mount. */
@@ -85,6 +87,9 @@ const AccordionPanel: FunctionComponent<IAccordionPanelProps> = (props) => {
  *   </AccordionItem>
  *   <AccordionItem id="two" label="Panel two">
  *     <p>Content two</p>
+ *   </AccordionItem>
+ *   <AccordionItem id="three" label="Settings" icon={IconName.settings}>
+ *     <p>Settings panel</p>
  *   </AccordionItem>
  * </Accordion>
  * ```
@@ -166,7 +171,7 @@ const Accordion: FunctionComponent<IAccordionProps> = (props) => {
 	return (
 		<div class={cx(styles.accordion, className)}>
 			{items.map((item, index) => {
-				const { id, label, children: itemChildren } = item.props;
+				const { id, label, icon, children: itemChildren } = item.props;
 				const triggerId = `${instanceId}-trigger-${id}`;
 				const panelId = `${instanceId}-panel-${id}`;
 				const isOpen = openIds.value.has(id);
@@ -180,12 +185,13 @@ const Accordion: FunctionComponent<IAccordionProps> = (props) => {
 								ref={(el) => {
 									triggerRefs.current[index] = el as HTMLButtonElement | null;
 								}}
-								class={styles.accordionTrigger}
+								class={cx(styles.accordionTrigger, icon && styles.accordionTriggerWithIcon)}
 								aria-expanded={isOpen ? 'true' : 'false'}
 								aria-controls={panelId}
 								onClick={() => toggleItem(id)}
 								onKeyDown={(e) => handleKeyDown(e, index)}
 							>
+								{icon ? <Icon name={icon} class={styles.accordionTriggerLeadIcon} /> : null}
 								{label}
 								<span class={styles.accordionTriggerIcon} aria-hidden="true">
 									<Icon name={IconName.chevronDown} />

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,3 +1,4 @@
+import Icon, { type IconName } from '@components/Icon';
 import type { IBaseProps } from '@internal/types';
 import { flattenChildren } from '@internal/utils';
 import { useSignal } from '@preact/signals';
@@ -18,6 +19,8 @@ interface ITabProps extends IBaseProps {
 	id: string;
 	/** Visible tab label text. */
 	label: string;
+	/** Optional leading icon rendered before the label. */
+	icon?: IconName;
 	/** Called when this tab is activated. */
 	onActivate?: () => void;
 	/**
@@ -93,6 +96,9 @@ const TabPanel: FunctionComponent<ITabPanelProps> = (props) => {
  *   </Tab>
  *   <Tab id="details" label="Details" onActivate={fetchDetails} eager>
  *     <p>Details content</p>
+ *   </Tab>
+ *   <Tab id="settings" label="Settings" icon={IconName.settings}>
+ *     <p>Settings panel</p>
  *   </Tab>
  * </TabGroup>
  * ```
@@ -222,7 +228,7 @@ const TabGroup: FunctionComponent<ITabGroupProps> = (props) => {
 		<div class={cx(styles.tabGroup, className)}>
 			<div ref={tablistRef} role="tablist" class={styles.tabList} onKeyDown={handleKeyDown}>
 				{tabs.map((tab) => {
-					const { id, label } = tab.props;
+					const { id, label, icon } = tab.props;
 					const isActive = activeId.value === id;
 					const tabDomId = `${instanceId}-tab-${id}`;
 					const panelDomId = `${instanceId}-tabpanel-${id}`;
@@ -240,6 +246,7 @@ const TabGroup: FunctionComponent<ITabGroupProps> = (props) => {
 							data-tab-id={id}
 							onClick={() => activateTab(id)}
 						>
+							{icon ? <Icon name={icon} class={styles.tabIcon} /> : null}
 							{label}
 						</button>
 					);

--- a/src/styles/Accordion.module.css
+++ b/src/styles/Accordion.module.css
@@ -38,6 +38,16 @@
 	background: var(--aui-color-background-hover);
 }
 
+.accordion-trigger-with-icon {
+	grid-template-columns: auto 1fr auto;
+	column-gap: 0.5em;
+}
+
+.accordion-trigger-lead-icon {
+	display: inline-grid;
+	place-items: center;
+}
+
 .accordion-trigger-icon {
 	display: inline-grid;
 	place-items: center;

--- a/src/styles/Tabs.module.css
+++ b/src/styles/Tabs.module.css
@@ -11,6 +11,10 @@
 
 .tab {
 	composes: focus-ring from "@styles/shared.css";
+	display: inline-grid;
+	grid-auto-flow: column;
+	align-items: center;
+	column-gap: 0.5em;
 	padding: 0.5em 1em;
 	border: none;
 	border-bottom: 2px solid transparent;
@@ -20,6 +24,12 @@
 	font: inherit;
 	cursor: pointer;
 	white-space: nowrap;
+}
+
+/* Icons render larger than the text — text is read, the icon is glanced. */
+.tab-icon {
+	width: 1.5em;
+	height: 1.5em;
 }
 
 .tab:hover {

--- a/tests/Accordion.test.tsx
+++ b/tests/Accordion.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import Accordion, { AccordionItem } from '@components/Accordion';
+import { IconName } from '@components/Icon';
 import { fireEvent, render } from '@testing-library/preact';
 import { HeadingLevel } from '@utils';
 
@@ -527,6 +528,40 @@ describe('Accordion', () => {
 			getByText('Content one');
 			getByText('Content two');
 			getByText('Content three');
+		});
+	});
+
+	describe('icon prop', () => {
+		it('preserves accessible name from label when icon is set', () => {
+			// Arrange & Act
+			const { getByRole } = render(
+				<Accordion>
+					<AccordionItem id="settings" label="Settings" icon={IconName.settings}>
+						Content
+					</AccordionItem>
+				</Accordion>
+			);
+
+			// Assert — icons are aria-hidden by Icon's lucide default; label remains the accessible name
+			expect(getByRole('button', { name: 'Settings' })).toBeTruthy();
+		});
+
+		it('does not affect open/close behavior when icon is set', () => {
+			// Arrange
+			const { getByRole } = render(
+				<Accordion>
+					<AccordionItem id="security" label="Security" icon={IconName.warning}>
+						Content
+					</AccordionItem>
+				</Accordion>
+			);
+
+			// Act
+			const trigger = getByRole('button', { name: 'Security' });
+			fireEvent.click(trigger);
+
+			// Assert
+			expect(trigger.getAttribute('aria-expanded')).toBe('true');
 		});
 	});
 });

--- a/tests/Tabs.test.tsx
+++ b/tests/Tabs.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { IconName } from '@components/Icon';
 import TabGroup, { Tab } from '@components/Tabs';
 import { fireEvent, render } from '@testing-library/preact';
 
@@ -696,6 +697,43 @@ describe('TabGroup', () => {
 					</TabGroup>
 				)
 			).toThrow('[TabGroup] Duplicate tab id: "dup". Tab ids must be unique.');
+		});
+	});
+
+	describe('icon prop', () => {
+		it('preserves accessible name from label when icon is set', () => {
+			// Arrange & Act
+			const { getByRole } = render(
+				<TabGroup>
+					<Tab id="search" label="Search" icon={IconName.search}>
+						Content
+					</Tab>
+				</TabGroup>
+			);
+
+			// Assert — icon is aria-hidden by Icon's lucide default; label remains the accessible name
+			expect(getByRole('tab', { name: 'Search' })).toBeTruthy();
+		});
+
+		it('does not affect tab activation when icon is set', () => {
+			// Arrange
+			const { getByRole } = render(
+				<TabGroup>
+					<Tab id="a" label="A" icon={IconName.search}>
+						Content A
+					</Tab>
+					<Tab id="b" label="B" icon={IconName.settings}>
+						Content B
+					</Tab>
+				</TabGroup>
+			);
+
+			// Act
+			fireEvent.click(getByRole('tab', { name: 'B' }));
+
+			// Assert
+			expect(getByRole('tab', { name: 'B' }).getAttribute('aria-selected')).toBe('true');
+			expect(getByRole('tab', { name: 'A' }).getAttribute('aria-selected')).toBe('false');
 		});
 	});
 });


### PR DESCRIPTION
### Added

- `icon?: IconName` prop on `<Tab>` and `<AccordionItem>` — renders a leading `<Icon>` before the label
- Tab icons render at `1.5em` for visual hierarchy against `1em` label text
- New `TabsSection` dev demo and icon variants in `AccordionSection`, both wired under the Disclosure tab

Fixes #81

### Notes

- Purely additive — `icon` is optional; existing consumers unaffected
- Icons inherit `aria-hidden` from `<Icon>`; accessible name still derives from `label`
- Accordion trigger swaps to a 3-column grid only when an icon is present (empty `auto` tracks still consume `column-gap`)

## Test Plan

- [x] 848 tests pass; typecheck and biome clean
- [x] /full-review — all reviewers PASS (testing-reviewer concerns addressed: dropped DOM-structure assertions, kept behavioral checks)
- [x] Manual smoke check in browser — confirmed icon alignment, sizing, hover/focus, keyboard nav