### PR TITLE
chore: add internal form primitives (DataInput, FieldError)

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,4 +1,5 @@
 import Icon, { IconName } from '@components/Icon';
+import FieldError from '@internal/FieldError';
 import type { IFieldProps } from '@internal/types';
 import { describeBy } from '@internal/utils';
 import styles from '@styles/Checkbox.module.css';
@@ -36,11 +37,7 @@ const Checkbox: FunctionComponent<ICheckboxProps> = (props) => {
 				<Icon name={IconName.check} class={styles.checkIcon} />
 				{label}
 			</label>
-			{error && (
-				<p id={errorId} class={styles.error} role="alert">
-					{error}
-				</p>
-			)}
+			{error && <FieldError id={errorId}>{error}</FieldError>}
 		</>
 	);
 };

--- a/src/components/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup.tsx
@@ -1,3 +1,4 @@
+import FieldError from '@internal/FieldError';
 import type { IBaseProps } from '@internal/types';
 import { describeBy } from '@internal/utils';
 import styles from '@styles/CheckboxGroup.module.css';
@@ -29,9 +30,9 @@ const CheckboxGroup: FunctionComponent<ICheckboxGroupProps> = (props) => {
 			<legend class={styles.legend}>{legend}</legend>
 			{children}
 			{error && (
-				<p id={errorId} class={styles.error} role="alert">
+				<FieldError id={errorId} class={styles.error}>
 					{error}
-				</p>
+				</FieldError>
 			)}
 		</fieldset>
 	);

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,19 +1,11 @@
+import DataInput, { type DataInputType } from '@internal/DataInput';
 import FormField from '@internal/FormField';
 import type { IFieldProps } from '@internal/types';
-import { describeBy } from '@internal/utils';
-import styles from '@styles/Input.module.css';
 import type { FunctionComponent } from 'preact';
 import { useId } from 'preact/hooks';
 
 /** Input types supported by the {@link Input} component. */
-export type InputType = 'text' | 'email' | 'url' | 'tel' | 'date' | 'time' | 'datetime-local';
-
-/** Types with unambiguous autocomplete mappings per WHATWG/WCAG. */
-const autocompleteByType: { [key: string]: string } = {
-	email: 'email',
-	tel: 'tel',
-	url: 'url',
-};
+export type InputType = DataInputType;
 
 /** Props for {@link Input}. */
 interface IInputProps extends IFieldProps {
@@ -40,7 +32,7 @@ const Input: FunctionComponent<IInputProps> = (props) => {
 	const {
 		label,
 		name,
-		type = 'text',
+		type,
 		value,
 		placeholder,
 		maxLength,
@@ -58,22 +50,21 @@ const Input: FunctionComponent<IInputProps> = (props) => {
 
 	return (
 		<FormField label={label} required={required} error={error} inputId={id} class={className}>
-			<input
-				class={styles.input}
+			<DataInput
 				id={id}
 				type={type}
 				name={name}
 				value={value}
 				placeholder={placeholder}
 				maxLength={maxLength}
-				autoComplete={autocomplete ?? autocompleteByType[type]}
+				autocomplete={autocomplete}
 				readOnly={readOnly}
 				pattern={pattern}
 				required={required}
 				disabled={disabled}
-				aria-invalid={!!error || undefined}
-				aria-describedby={describeBy(error && errorId)}
-				onInput={onInput && ((e) => onInput((e.target as HTMLInputElement).value))}
+				error={error}
+				ariaDescribedby={error ? errorId : undefined}
+				onInput={onInput}
 			/>
 		</FormField>
 	);

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -1,3 +1,4 @@
+import FieldError from '@internal/FieldError';
 import type { IBaseProps } from '@internal/types';
 import { describeBy, flattenChildren } from '@internal/utils';
 import styles from '@styles/RadioGroup.module.css';
@@ -104,9 +105,9 @@ const RadioGroup: FunctionComponent<IRadioGroupProps> = (props) => {
 				);
 			})}
 			{error && (
-				<p id={errorId} class={styles.error} role="alert">
+				<FieldError id={errorId} class={styles.error}>
 					{error}
-				</p>
+				</FieldError>
 			)}
 		</fieldset>
 	);

--- a/src/internal/DataInput.tsx
+++ b/src/internal/DataInput.tsx
@@ -1,0 +1,106 @@
+import type { IBaseProps } from '@internal/types';
+import styles from '@styles/DataInput.module.css';
+import { cx } from '@utils';
+import type { FunctionComponent } from 'preact';
+
+/** Input types supported by the {@link DataInput} primitive. */
+export type DataInputType = 'text' | 'email' | 'url' | 'tel' | 'date' | 'time' | 'datetime-local';
+
+/** Types with unambiguous autocomplete mappings per WHATWG/WCAG. */
+const autocompleteByType: { [key: string]: string } = {
+	email: 'email',
+	tel: 'tel',
+	url: 'url',
+};
+
+/** Props for {@link DataInput}. */
+interface IDataInputProps extends IBaseProps {
+	/** Element id. Use when an external `<label for>` references this input, or for `aria-describedby` targets. */
+	id?: string;
+	/** ID of an element (typically a column `<th>`) whose text labels this input. Use when no `<label for>` association is in scope. */
+	ariaLabelledby?: string;
+	/** HTML input type. Defaults to `'text'`. */
+	type?: DataInputType;
+	/** Form name attribute. Optional — tabular consumers often manage state externally. */
+	name?: string;
+	/** Current input value. */
+	value?: string;
+	/** Placeholder text. */
+	placeholder?: string;
+	/** Maximum character length. */
+	maxLength?: number;
+	/** Autocomplete hint. Defaults automatically for `email`, `tel`, and `url` types. */
+	autocomplete?: string;
+	/** Whether the field is read-only (focusable, submitted, copyable — distinct from disabled). */
+	readOnly?: boolean;
+	/** Validation pattern (regex string). */
+	pattern?: string;
+	/** Whether the field is required. */
+	required?: boolean;
+	/** Whether the field is disabled. */
+	disabled?: boolean;
+	/** Truthy sets `aria-invalid="true"`. The message is rendered separately (see `FieldError`). */
+	error?: string;
+	/** Called with the new value on input. */
+	onInput?: (value: string) => void;
+	/** ID(s) of element(s) that describe this input — typically a `FieldError` rendered nearby. */
+	ariaDescribedby?: string;
+}
+
+/**
+ * Internal styled-input primitive composed by {@link Input} (with `FormField`)
+ * and by tabular contexts (where a column `<th>` provides the accessible name
+ * via `ariaLabelledby`).
+ *
+ * The composer is responsible for wiring an accessible name — either an
+ * external `<label for={id}>` association, or `ariaLabelledby` referencing
+ * existing label text. `DataInput` does not enforce labelling at the type
+ * level because all callers are internal and verified.
+ *
+ * Sets `aria-invalid` from the truthiness of `error`. Does not render the
+ * error message — the composer (or a sibling `FieldError`) handles that and
+ * wires `ariaDescribedby` to its id.
+ */
+const DataInput: FunctionComponent<IDataInputProps> = (props) => {
+	const {
+		id,
+		type = 'text',
+		name,
+		value,
+		placeholder,
+		maxLength,
+		autocomplete,
+		readOnly,
+		pattern,
+		required,
+		disabled,
+		error,
+		onInput,
+		ariaLabelledby,
+		ariaDescribedby,
+		class: className,
+	} = props;
+
+	return (
+		<input
+			class={cx(styles.input, className)}
+			id={id}
+			type={type}
+			name={name}
+			value={value}
+			placeholder={placeholder}
+			maxLength={maxLength}
+			autoComplete={autocomplete ?? autocompleteByType[type]}
+			readOnly={readOnly}
+			pattern={pattern}
+			required={required}
+			disabled={disabled}
+			aria-invalid={!!error || undefined}
+			aria-labelledby={ariaLabelledby}
+			aria-describedby={ariaDescribedby}
+			onInput={onInput && ((e) => onInput((e.target as HTMLInputElement).value))}
+		/>
+	);
+};
+
+export default DataInput;

--- a/src/internal/FieldError.tsx
+++ b/src/internal/FieldError.tsx
@@ -1,0 +1,32 @@
+import type { IBaseProps } from '@internal/types';
+import styles from '@styles/FieldError.module.css';
+import { cx } from '@utils';
+import type { ComponentChildren, FunctionComponent } from 'preact';
+
+/** Props for {@link FieldError}. */
+interface IFieldErrorProps extends IBaseProps {
+	/** ID for `aria-describedby` wiring from the associated input. */
+	id: string;
+	/** Error message text. */
+	children: ComponentChildren;
+}
+
+/**
+ * Inline form-error message with `role="alert"`.
+ * Intended for use alongside form controls (`Input`, `DataInput`, etc.) where
+ * the consumer wires `aria-describedby` from the input to this element's `id`.
+ *
+ * Used internally by {@link FormField} for the standard form path, and exposed
+ * publicly so consumers placing inputs in custom layouts (tabular cells,
+ * toolbars) can render a consistently-styled error message.
+ */
+const FieldError: FunctionComponent<IFieldErrorProps> = (props) => {
+	const { id, children, class: className } = props;
+	return (
+		<p id={id} class={cx(styles.error, className)} role="alert">
+			{children}
+		</p>
+	);
+};
+
+export default FieldError;

--- a/src/internal/FormField.tsx
+++ b/src/internal/FormField.tsx
@@ -1,3 +1,4 @@
+import FieldError from '@internal/FieldError';
 import type { IBaseProps } from '@internal/types';
 import styles from '@styles/FormField.module.css';
 import { cx } from '@utils';
@@ -41,9 +42,9 @@ const FormField: FunctionComponent<IFormFieldProps> = (props) => {
 			</label>
 			{children}
 			{error && (
-				<p id={errorId} class={styles.error} role="alert">
+				<FieldError id={errorId} class={styles.error}>
 					{error}
-				</p>
+				</FieldError>
 			)}
 		</div>
 	);

--- a/src/styles/Checkbox.module.css
+++ b/src/styles/Checkbox.module.css
@@ -43,7 +43,3 @@
 .field:has(.input:disabled) .input {
 	cursor: not-allowed;
 }
-
-.error {
-	composes: field-error from "@styles/shared.css";
-}

--- a/src/styles/CheckboxGroup.module.css
+++ b/src/styles/CheckboxGroup.module.css
@@ -9,6 +9,5 @@
 }
 
 .error {
-	composes: field-error from "@styles/shared.css";
 	grid-column: 1 / -1;
 }

--- a/src/styles/DataInput.module.css
+++ b/src/styles/DataInput.module.css
@@ -1,0 +1,3 @@
+.input {
+	composes: text-input focus-ring disabled from "@styles/shared.css";
+}

--- a/src/styles/FieldError.module.css
+++ b/src/styles/FieldError.module.css
@@ -1,0 +1,3 @@
+.error {
+	composes: field-error from "@styles/shared.css";
+}

--- a/src/styles/FormField.module.css
+++ b/src/styles/FormField.module.css
@@ -14,6 +14,5 @@
 }
 
 .error {
-	composes: field-error from "@styles/shared.css";
 	grid-column: 2;
 }

--- a/src/styles/Input.module.css
+++ b/src/styles/Input.module.css
@@ -1,3 +1,0 @@
-.input {
-	composes: text-input focus-ring disabled from "@styles/shared.css";
-}

--- a/src/styles/RadioGroup.module.css
+++ b/src/styles/RadioGroup.module.css
@@ -55,6 +55,5 @@
 }
 
 .error {
-	composes: field-error from "@styles/shared.css";
 	grid-column: 1 / -1;
 }

--- a/tests/a11y/data-input.a11y.test.tsx
+++ b/tests/a11y/data-input.a11y.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'bun:test';
+import DataInput from '@internal/DataInput';
+import FieldError from '@internal/FieldError';
+import { render } from '@testing-library/preact';
+import { renderAndCheckA11y } from './setup';
+
+describe('DataInput a11y', () => {
+	const headerId = 'col-name';
+
+	function withinTable(cell: ReturnType<typeof DataInput>) {
+		return (
+			<table>
+				<thead>
+					<tr>
+						<th id={headerId}>Name</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>{cell}</td>
+					</tr>
+				</tbody>
+			</table>
+		);
+	}
+
+	it('has no axe violations in a tabular layout', async () => {
+		// Act & Assert
+		await renderAndCheckA11y(withinTable(<DataInput ariaLabelledby={headerId} />));
+	});
+
+	// https://www.w3.org/TR/WCAG22/#compatible
+	describe('WCAG A', () => {
+		it('resolves accessible name from ariaLabelledby (SC 4.1.2)', () => {
+			// Act
+			const { getByRole } = render(withinTable(<DataInput ariaLabelledby={headerId} />));
+
+			// Assert: input is queryable by the column header text
+			getByRole('textbox', { name: /Name/ });
+		});
+
+		it('exposes the disabled state (SC 4.1.2)', () => {
+			// Act
+			const { getByRole } = render(withinTable(<DataInput ariaLabelledby={headerId} disabled />));
+			const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+			// Assert
+			expect(input.disabled).toBe(true);
+		});
+
+		it('exposes the required state (SC 4.1.2)', () => {
+			// Act
+			const { getByRole } = render(withinTable(<DataInput ariaLabelledby={headerId} required />));
+			const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+			// Assert
+			expect(input.required).toBe(true);
+		});
+
+		it('exposes the readOnly state (SC 4.1.2)', () => {
+			// Act
+			const { getByRole } = render(withinTable(<DataInput ariaLabelledby={headerId} readOnly />));
+			const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+			// Assert
+			expect(input.readOnly).toBe(true);
+		});
+
+		it('marks the input invalid when error is set (SC 3.3.1)', () => {
+			// Act
+			const { getByRole } = render(
+				withinTable(<DataInput ariaLabelledby={headerId} error="bad value" />)
+			);
+			const input = getByRole('textbox', { name: /Name/ });
+
+			// Assert
+			expect(input.getAttribute('aria-invalid')).toBe('true');
+		});
+
+		it('wires aria-describedby to a sibling FieldError (SC 3.3.1)', () => {
+			// Arrange
+			const errorId = 'row-1-error';
+
+			// Act
+			const { getByRole, getByText } = render(
+				withinTable(
+					<>
+						<DataInput ariaLabelledby={headerId} ariaDescribedby={errorId} error="bad value" />
+						<FieldError id={errorId}>bad value</FieldError>
+					</>
+				)
+			);
+			const input = getByRole('textbox', { name: /Name/ });
+			const errorEl = getByText('bad value');
+
+			// Assert
+			expect(input.getAttribute('aria-describedby')).toBe(errorEl.id);
+		});
+	});
+
+	// https://www.w3.org/TR/WCAG22/#input-purposes
+	describe('WCAG AA', () => {
+		it('derives autocomplete from input type (SC 1.3.5)', () => {
+			// Arrange
+			const types = [
+				{ type: 'email' as const, expected: 'email' },
+				{ type: 'tel' as const, expected: 'tel' },
+				{ type: 'url' as const, expected: 'url' },
+			];
+
+			for (const { type, expected } of types) {
+				// Act
+				const { getByRole, unmount } = render(
+					withinTable(<DataInput ariaLabelledby={headerId} type={type} />)
+				);
+				const input = getByRole('textbox', { name: /Name/ });
+
+				// Assert
+				expect(input.getAttribute('autocomplete')).toBe(expected);
+				unmount();
+			}
+		});
+	});
+});

--- a/tests/data-input.test.tsx
+++ b/tests/data-input.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, mock } from 'bun:test';
+import DataInput from '@internal/DataInput';
+import { fireEvent, render } from '@testing-library/preact';
+
+describe('DataInput', () => {
+	const headerId = 'col-name';
+
+	function renderWithHeader(node: ReturnType<typeof DataInput>) {
+		return render(
+			<>
+				<span id={headerId}>Name</span>
+				{node}
+			</>
+		);
+	}
+
+	it('defaults to type="text"', () => {
+		// Act
+		const { getByRole } = renderWithHeader(<DataInput ariaLabelledby={headerId} />);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.type).toBe('text');
+	});
+
+	it('accepts a custom type', () => {
+		// Act
+		const { getByRole } = renderWithHeader(<DataInput ariaLabelledby={headerId} type="email" />);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.type).toBe('email');
+	});
+
+	it('calls onInput with the value', () => {
+		// Arrange
+		const handleInput = mock(() => {});
+		const { getByRole } = renderWithHeader(
+			<DataInput ariaLabelledby={headerId} onInput={handleInput} />
+		);
+
+		// Act
+		fireEvent.input(getByRole('textbox', { name: /Name/ }), {
+			target: { value: 'gh' },
+		});
+
+		// Assert
+		expect(handleInput).toHaveBeenCalledWith('gh');
+	});
+
+	it('sets the name attribute', () => {
+		// Act
+		const { getByRole } = renderWithHeader(
+			<DataInput ariaLabelledby={headerId} name="row-1-name" />
+		);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.name).toBe('row-1-name');
+	});
+
+	it('omits the name attribute when not provided', () => {
+		// Act
+		const { getByRole } = renderWithHeader(<DataInput ariaLabelledby={headerId} />);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.hasAttribute('name')).toBe(false);
+	});
+
+	it('sets maxLength on the input', () => {
+		// Act
+		const { getByRole } = renderWithHeader(<DataInput ariaLabelledby={headerId} maxLength={50} />);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.maxLength).toBe(50);
+	});
+
+	it('sets pattern on the input', () => {
+		// Arrange
+		const pattern = '[A-Za-z]+';
+
+		// Act
+		const { getByRole } = renderWithHeader(
+			<DataInput ariaLabelledby={headerId} pattern={pattern} />
+		);
+		const input = getByRole('textbox', { name: /Name/ }) as HTMLInputElement;
+
+		// Assert
+		expect(input.pattern).toBe(pattern);
+	});
+
+	it('derives autocomplete for email/tel/url types', () => {
+		// Arrange
+		const types = [
+			{ type: 'email' as const, expected: 'email' },
+			{ type: 'tel' as const, expected: 'tel' },
+			{ type: 'url' as const, expected: 'url' },
+		];
+
+		for (const { type, expected } of types) {
+			// Act
+			const { getByRole, unmount } = renderWithHeader(
+				<DataInput ariaLabelledby={headerId} type={type} />
+			);
+			const input = getByRole('textbox', { name: /Name/ });
+
+			// Assert
+			expect(input.getAttribute('autocomplete')).toBe(expected);
+			unmount();
+		}
+	});
+
+	it('allows autocomplete override for derived types', () => {
+		// Act
+		const { getByRole } = renderWithHeader(
+			<DataInput ariaLabelledby={headerId} type="email" autocomplete="work email" />
+		);
+		const input = getByRole('textbox', { name: /Name/ });
+
+		// Assert
+		expect(input.getAttribute('autocomplete')).toBe('work email');
+	});
+
+	it('forwards the class prop onto the input', () => {
+		// Act
+		const { getByRole } = renderWithHeader(<DataInput ariaLabelledby={headerId} class="extra" />);
+		const input = getByRole('textbox', { name: /Name/ });
+
+		// Assert
+		expect(input.className.split(' ')).toContain('extra');
+	});
+});


### PR DESCRIPTION
Internal refactoring to extract reusable input and error-message primitives, enabling consistent error handling across form components.

### Changed

- **DataInput** — new internal bare-input primitive with autocomplete derivation, value extraction, and aria-invalid wiring
- **FieldError** — new internal styled error-message helper (`<p role="alert">`) with pass-through class support
- **Input** — refactored to compose `<FormField><DataInput /></FormField>`
  - Inline input JSX, autocompleteByType map, and aria wiring move into DataInput
  - Public API unchanged
- **FormField, Checkbox, CheckboxGroup, RadioGroup** — refactored to render `<FieldError>` instead of inline `<p role="alert">`
  - Single source of truth for error styling and markup
- **CSS modules** — component error styles drop `composes: field-error` (FieldError owns it); layout rules (grid-column) remain

### Context

These primitives support future features that build tabular forms with external labelling (see #158, #157). Internal scope means no version bump. Existing 866 tests pass.

Fixes #156