### PR TITLE
Update from app-id to client-id

### DIFF
--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -15,5 +15,5 @@ jobs:
       pr-sha: ${{ github.event.pull_request.head.sha }}
       version-file: 'package.json'
     secrets:
-      app-id: ${{ secrets.MERGE_APP_ID }}
+      client-id: ${{ secrets.MERGE_CLIENT_ID }}
       private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

Use modern Client ID vs old-style App ID for merge bot compatibility

## Changes

- Update readiness variable definition to reference client-id secret